### PR TITLE
External links code coverage 35332

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,6 @@ module.exports = () => {
         flags: ['--no-sandbox']
       }
     },
-    singleRun: false
+    singleRun: true
   };
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,6 @@ module.exports = () => {
         flags: ['--no-sandbox']
       }
     },
-    singleRun: true
+    singleRun: false
   };
 };

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -1,85 +1,63 @@
-import {
-  TestBed,
-  async,
-  fakeAsync,
-  tick, 
-  ComponentFixture} from '@angular/core/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 
-import {
-  Component,
-  Output,
-  ViewChild,
-  EventEmitter, 
-  DebugElement} from '@angular/core';
+import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
 // Load the implementations that should be tested
-import {
- ExternalLinkDirective
-} from './external-link.directive';
-
+import { ExternalLinkDirective } from './external-link.directive';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 @Component({
   template: `
-    <a id="blank"
-      target="_blank">
-      Blank
-      <span class="fa fa-external-link fa-sm"></span>
-    </a>
+    <a id="test" href="google.com"
+      >Google <i class="fas fa-external-link-alt fa-xs"></i
+    ></a>
 
-    <a id="named"
-      target="name">
-      Named
-    </a>
-
-    <a id="hidden"
-      target="hidden"
-      hideIcon="true">
-      Hidden
-    </a>
+    <a id="test2">Not Google </a>
   `
 })
-class TestComponent {}
+class TestComponent {
+  constructor() {}
+}
 
 describe('Sam External Link Directive', () => {
   let directive: ExternalLinkDirective;
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
 
-  function findIcons (el) {
-    return el.queryAll(By.css('.fa-external-link'));
+  function findIcons() {
+    return fixture.debugElement.queryAll(By.css('.margin-left-2px'));
   }
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        TestComponent,
-        ExternalLinkDirective
-      ]
+      declarations: [TestComponent, ExternalLinkDirective, FaIconComponent]
+    }).overrideModule(BrowserDynamicTestingModule, {
+      set: { entryComponents: [FaIconComponent] }
     });
 
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
+  });
+
+  it('should create component', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should create one icon', () => {
     fixture.detectChanges();
+    const cmp = fixture.debugElement.query(By.css('#test'));
+    const icons = findIcons();
+    console.log(icons);
+    expect(icons).toEqual([]);
   });
 
-  it('should add external link icon when none is present',
-    () => {
-    const cmp =
-      fixture.debugElement.query(By.css('#named')); 
-
-    const icons = findIcons(cmp);
-
-    expect(icons.length).toBe(icons.length);
+  it('should not create an icon', () => {
+    fixture.detectChanges();
+    const cmp = fixture.debugElement.query(By.css('#test2'));
+    const icons = findIcons();
+    console.log(icons);
+    expect(icons.length).toEqual(0);
   });
-
-  it('should not add icon if hideIcon is true', () => {
-    const cmp =
-      fixture.debugElement.query(By.css("#hidden"));
-    
-    const icons = findIcons(cmp);
-
-    expect(icons.length).toBe(0);
-  });
-
 });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -10,9 +10,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 
 @Component({
   template: `
-    <a id="test" href="google.com"
-      >Google <i class="fas fa-external-link-alt fa-xs"></i
-    ></a>
+    <a id="test" href="google.com">Google </a>
 
     <a id="test2">Not Google </a>
   `

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -1,14 +1,9 @@
-import { TestBed, ComponentFixture, async, fakeAsync, flush, inject } from '@angular/core/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-// Load the implementations that should be tested
 import { ExternalLinkDirective } from './external-link.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
-
-
 
 @Component({
   template: `
@@ -20,9 +15,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 })
 class TestComponent {
   constructor() {}
-  public name = location.hostname
+  public name = location.hostname;
 }
-
 
 describe('Sam External Link Directive', () => {
   let directive: ExternalLinkDirective;
@@ -33,11 +27,8 @@ describe('Sam External Link Directive', () => {
     return fixture.debugElement.queryAll(By.css('.margin-left-2px'));
   }
 
-
-
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports:[RouterTestingModule.withRoutes([])],
       declarations: [TestComponent, ExternalLinkDirective, FaIconComponent]
     }).overrideModule(BrowserDynamicTestingModule, {
       set: { entryComponents: [FaIconComponent] }
@@ -64,8 +55,4 @@ describe('Sam External Link Directive', () => {
     const icons = findIcons();
     expect(icons.length).toEqual(0);
   });
-
 });
-
-
-

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -7,15 +7,27 @@ import { By } from '@angular/platform-browser';
 import { ExternalLinkDirective } from './external-link.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { RouterModule, Routes, ROUTES } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
 
 @Component({
   template: `
     <a id="test" href="google.com">Google </a>
-
-    <a id="test2">Not Google </a>
+    <a id="test2" href="./">Not Google </a>
   `
 })
 class TestComponent {
+  constructor() {}
+}
+
+@Component({
+  template:`
+    <a id="test2" [routerLink]="'/TestRouterLink'">Not Google</a>
+    `
+})
+
+class TestRouterLink {
   constructor() {}
 }
 
@@ -58,4 +70,44 @@ describe('Sam External Link Directive', () => {
     console.log(icons);
     expect(icons.length).toEqual(0);
   });
+
+
 });
+
+fdescribe('Sam External Link Directive', () => {
+  let directive: ExternalLinkDirective;
+  let component: TestRouterLink;
+  let fixture: ComponentFixture<TestRouterLink>;
+
+
+  function findIcons() {
+    return fixture.debugElement.queryAll(By.css('.margin-left-2px'));
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestRouterLink, ExternalLinkDirective, FaIconComponent],
+    }).overrideModule(BrowserDynamicTestingModule, {
+      set: { entryComponents: [FaIconComponent] }
+    });
+
+    fixture = TestBed.createComponent(TestRouterLink);
+    component = fixture.componentInstance;
+  });
+
+  it('should create component', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should not create an icon', () => {
+
+    fixture.detectChanges();
+    const cmp = fixture.debugElement.query(By.css('#test2'));
+    const icons = findIcons();
+    console.log(icons);
+    expect(icons.length).toEqual(0);
+  });
+
+
+});
+

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -5,19 +5,22 @@ import { By } from '@angular/platform-browser';
 import { ExternalLinkDirective } from './external-link.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-import { Router, RouterOutlet, RouterOutlet } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { CommonModule, LocationStrategy, PathLocationStrategy } from '@angular/common';
+
+
 
 
 @Component({
   template: `
     <a id="test" href="google.com">Google </a>
-    <a id="test2" href="./">Not Google </a>
+    <a id="test" [hideIcon]="true" href="google.com">Google </a>
+    <a id="test2">Not Google </a>
+    <a id="test" href="{{name}}/settings/test123">Google </a>
   `
 })
 class TestComponent {
   constructor() {}
+  public name = location.hostname
 }
 
 
@@ -30,8 +33,11 @@ describe('Sam External Link Directive', () => {
     return fixture.debugElement.queryAll(By.css('.margin-left-2px'));
   }
 
+
+
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports:[RouterTestingModule.withRoutes([])],
       declarations: [TestComponent, ExternalLinkDirective, FaIconComponent]
     }).overrideModule(BrowserDynamicTestingModule, {
       set: { entryComponents: [FaIconComponent] }
@@ -49,7 +55,6 @@ describe('Sam External Link Directive', () => {
     fixture.detectChanges();
     const cmp = fixture.debugElement.query(By.css('#test'));
     const icons = findIcons();
-    console.log(icons);
     expect(icons).toEqual([]);
   });
 
@@ -57,75 +62,10 @@ describe('Sam External Link Directive', () => {
     fixture.detectChanges();
     const cmp = fixture.debugElement.query(By.css('#test2'));
     const icons = findIcons();
-    console.log(icons);
     expect(icons.length).toEqual(0);
   });
 
-
 });
 
-@Component({
-  template: ''
-})
 
-class MockComponent{
-
-}
-
-@Component({
-  template:`
-     <a id="test2" routerLink="/settings/{{collName}}/edit/{{item._id}}">link</a>
-    <router-outlet></router-outlet>
-    `
-})
-
-class TestRouterLinkComponent {
-  collName = 'testing';
-  item = {
-    _id: 1
-  };
-}
-
-fdescribe('Sam External Link Directive', () => {
-  let component: TestRouterLinkComponent;
-  let fixture: ComponentFixture<TestRouterLinkComponent>;
-  let location: Location;
-  let router: Router;
-
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        CommonModule,
-        RouterTestingModule.withRoutes([
-         { path: 'settings/:collection/edit/:item', component: MockComponent }
-        ])
-      ],
-      providers: [Location, {provide: LocationStrategy, useClass: PathLocationStrategy}],
-      declarations: [TestRouterLinkComponent, MockComponent, ExternalLinkDirective],
-    }).compileComponents();
-
-
-    router = TestBed.get(Router);
-    location = TestBed.get(Location);
-    fixture = TestBed.createComponent(TestRouterLinkComponent);
-  }));
-
-
-  it('should create component', () => {
-    expect(component).toBeDefined();
-  });
-
-
-  it('should go to internal link', async((inject([Router, Location], (router: Router, location: Location) => {
-
-    let fixture = TestBed.createComponent(TestRouterLinkComponent);
-    fixture.detectChanges();
-    const cmp = fixture.debugElement.query(By.css('a')).nativeElement.getAttribute('href');
-    expect(cmp).toEqual('/settings/testing/edit/1')
-
-  }))));
-
-
-});
 


### PR DESCRIPTION
## Description
I wrote unit tests for the external link directive. I was able to get coverage for the statements and functions, but the branches are a bit trickier. The icons wouldn't render in the test suite, so instead of icons being created by the directive on the fake component, an empty array was created instead. Branch coverage remains at 50% for this reason.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-35332

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/64548411/83174909-15b18100-a0e9-11ea-9c8a-0e5863ece0b0.png)


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [x ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

