### PR TITLE
Make the combo box pick up alt key

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
@@ -257,6 +257,10 @@ export class SDSAutocompleteSearchComponent implements ControlValueAccessor {
    * @param event
    */
   onKeydown(event): void {
+    if(KeyHelper.is(KEYS.ALT, event)){  
+      event.preventDefault();
+      this.inputFocusHandler();
+    }
     if (KeyHelper.is(KEYS.TAB, event)) {
       return;
     } else if (KeyHelper.is(KEYS.BACKSPACE, event)) {

--- a/libs/packages/components/src/lib/key-helper/key-helper.ts
+++ b/libs/packages/components/src/lib/key-helper/key-helper.ts
@@ -3,7 +3,7 @@ export class KeyHelper {
   private _allowedKeys: string[] = [];
 
   private _currentlySupported = [
-    'enter','up','down','left','right','tab','esc','space',
+    'alt','enter','up','down','left','right','tab','esc','space',
     'shift','backspace','1','2','3','4','5','6','7','8',
     '9','0', 'delete'
   ];
@@ -79,6 +79,8 @@ export class KeyHelper {
     event: KeyboardEvent | any): boolean {
     let lowercased = validKeyParam.toLowerCase();
     switch (lowercased) {
+      case 'alt'  :
+        return this._isAltKey(event);
       case 'enter':
         return this._isEnter(event);
       case 'up':
@@ -138,6 +140,19 @@ export class KeyHelper {
       return false;
     }
   }
+  private static _isAltKey (e: KeyboardEvent | any) {
+    if (e.code === 'Alt'
+      || e.key === 'Alt'
+      || e.keyIdentifier === 'Alt'
+      || e.which === 18
+      || e.charCode === 18
+      || e.keyCode === 18) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
 
   private static _isArrowUp (e: KeyboardEvent | any) {
     if (e.code === 'ArrowUp'
@@ -414,6 +429,7 @@ export class KeyHelper {
 
 export enum KEYS {
   'ENTER' = 'enter',
+  'ALT' = 'alt',
   'UP' = 'up',
   'DOWN' = 'down',
   'LEFT' = 'left',


### PR DESCRIPTION
one of the problems with accessibility that the dropdown wasn't responding to the alt + down combination. JAWS would state that dropdown is open but it wouldn't actually open it.
 Looking at the code it doesn't seem to like its meant to handle multiple keys at the same time, so maybe just binding it to alt key is a viable solution.?

