### PR TITLE
Fix subheader demos and searchbar blur

### DIFF
--- a/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.component.html
+++ b/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.component.html
@@ -2,7 +2,7 @@
   <div class="wide-container">
     <sds-subheader>
       <!-- =============== BACK BUTTON =============== -->
-      <button class="sds-button sds-button--circular sds-navbar__back-button" style="margin-right: 1em;">
+      <button class="sds-button sds-button--circular sds-navbar__back-button">
         <sds-icon [icon]="['bs', 'chevron-left']"></sds-icon>
         <span class="usa-sr-only">Go Back</span>
       </button>
@@ -14,7 +14,6 @@
 
       <!-- =============== SEARCH =============== -->
       <sds-search
-        (term)="log($event)"
         parentSelector=".grid-row"
         placeholder="Entity an entity ID, name, or keyword"
         inputClass="width-card-lg widescreen:width-mobile display-none desktop-lg:display-inline-block"

--- a/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.component.ts
+++ b/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.component.ts
@@ -1,10 +1,8 @@
-import { Component, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { FormGroup } from '@angular/forms';
 import {
   SdsDialogService,
-  SdsDialogRef,
-  SDS_DIALOG_DATA
 } from '@gsa-sam/components';
 import {
   SdsFormlyDialogComponent,
@@ -27,9 +25,6 @@ export class SubheaderSearchSubPagesComponent {
       { id: 'ShareBtn', icon: 'bars', text: 'Share' }
     ]
   };
-  log(value) {
-    console.log(`%cLog: ${value}`, 'color: blue; font-weight: bold');
-  }
   // Code begin for download
   fields: FormlyFieldConfig[] = [
     {

--- a/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.module.ts
+++ b/libs/documentation/src/lib/components/subheader/demos/search-sub-pages/subheader-search-sub-pages.module.ts
@@ -26,7 +26,6 @@ import { SdsButtonGroupModule } from 'libs/packages/sam-material-extensions/src/
     ReactiveFormsModule,
     SdsFormlyModule,
     FormlyModule,
-    // FormlyModule,
     SdsIconModule,
     SdsButtonGroupModule
   ],

--- a/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.component.html
+++ b/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.component.html
@@ -14,7 +14,6 @@
 
       <!-- =============== SEARCH =============== -->
       <sds-search
-        (term)="log($event)"
         parentSelector=".grid-row"
         placeholder="Entity an entity ID, name, or keyword"
         inputClass="width-card-lg widescreen:width-mobile display-none desktop-lg:display-inline-block"

--- a/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.component.ts
+++ b/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.component.ts
@@ -1,10 +1,8 @@
-import { Component, Inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { FormGroup } from '@angular/forms';
 import {
   SdsDialogService,
-  SdsDialogRef,
-  SDS_DIALOG_DATA
 } from '@gsa-sam/components';
 import {
   SdsFormlyDialogComponent,
@@ -27,9 +25,7 @@ export class SubheaderSearchComponent {
       { id: 'ShareBtn', icon: 'bars', text: 'Share' }
     ]
   };
-  log(value) {
-    console.log(`%cLog: ${value}`, 'color: blue; font-weight: bold');
-  }
+
   // Code begin for download
   fields: FormlyFieldConfig[] = [
     {

--- a/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.module.ts
+++ b/libs/documentation/src/lib/components/subheader/demos/search/subheader-search.module.ts
@@ -25,7 +25,6 @@ import { SubheaderSearchComponent } from './subheader-search.component';
     ReactiveFormsModule,
     SdsFormlyModule,
     FormlyModule,
-    // FormlyModule,
     SdsIconModule
   ],
   declarations: [SubheaderSearchComponent],

--- a/libs/documentation/src/lib/components/subheader/demos/tier-2-workspace/subheader-tier-2-workspace.component.html
+++ b/libs/documentation/src/lib/components/subheader/demos/tier-2-workspace/subheader-tier-2-workspace.component.html
@@ -2,7 +2,7 @@
   <div class="wide-container">
     <sds-subheader>
       <!-- =============== BACK BUTTON =============== -->
-      <button class="sds-button sds-button--circular sds-navbar__back-button" style="margin-right: 1em;">
+      <button class="sds-button sds-button--circular sds-navbar__back-button">
         <sds-icon [icon]="['bs', 'chevron-left']"></sds-icon>
         <span class="usa-sr-only">Go Back</span>
       </button>
@@ -14,7 +14,6 @@
 
       <!-- =============== SEARCH =============== -->
       <sds-search
-        (term)="log($event)"
         parentSelector=".grid-row"
         placeholder="Entity an entity ID, name, or keyword"
         inputClass="width-card-lg widescreen:width-mobile display-none desktop-lg:display-inline-block"

--- a/libs/documentation/src/lib/components/subheader/demos/tier-2-workspace/subheader-tier-2-workspace.module.ts
+++ b/libs/documentation/src/lib/components/subheader/demos/tier-2-workspace/subheader-tier-2-workspace.module.ts
@@ -26,7 +26,6 @@ import { SdsButtonGroupModule } from 'libs/packages/sam-material-extensions/src/
     ReactiveFormsModule,
     SdsFormlyModule,
     FormlyModule,
-    // FormlyModule,
     SdsIconModule,
     SdsButtonGroupModule
   ],

--- a/libs/packages/components/src/lib/search/search.component.html
+++ b/libs/packages/components/src/lib/search/search.component.html
@@ -21,7 +21,7 @@
 <ng-template #inputTemplate>
   <label class="usa-sr-only" for="search-field">Search</label>
   <input #inputEl [value]="model.searchText? model.searchText :''" [ngClass]="inputClass" id="search-field" type="search" class="usa-input"
-    name="search" [placeholder]="searchSettings.placeholder? searchSettings.placeholder : 'type here'" />
+    name="search" [placeholder]="searchSettings.placeholder? searchSettings.placeholder : 'type here'" (blur)="focusChange();"/>
   <button #buttonEl class="usa-button" type="submit"  (click)="handleClick($event)">
     <span class="usa-sr-only">Search</span>
   </button>

--- a/libs/packages/components/src/lib/search/search.component.ts
+++ b/libs/packages/components/src/lib/search/search.component.ts
@@ -130,14 +130,14 @@ export class SdsSearchComponent implements AfterViewInit, ControlValueAccessor {
     this.inputState.visible = false;
   }
 
-  focusChange(event) {
-    if (event === null && !this.inputState.initial.visible) {
+  focusChange() {
+    if (!this.inputState.initial.visible) {
       this.removeInputVisibleStyles();
     }
   }
 
   calculateInputWidth(): number {
-    const leftPadding = 16;
+    const leftPadding = 20;
     const buttonElement = this.buttonEl.nativeElement;
     const inputElement = this.inputEl.nativeElement;
     const rightPosition = buttonElement.getBoundingClientRect().left;

--- a/libs/packages/components/src/lib/search/search.spec.ts
+++ b/libs/packages/components/src/lib/search/search.spec.ts
@@ -84,7 +84,7 @@ describe('SearchComponent', () => {
   it('Should trigger focus event', () => {
     const e = null;
     component.inputState.initial.visible = true;
-    component.focusChange(e);
+    component.focusChange();
     fixture.detectChanges();
     expect(component.inputEl.nativeElement.style.display).toBe('');
     expect(component.inputEl.nativeElement.style.position).toBe('');


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Tweaks to the subheader demos were requested. Also it was raised that the seachbar staying expanded on tablet/mobile was not desired.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

