### PR TITLE
IAE-4429 Update search model writing behavior

### DIFF
--- a/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.component.html
+++ b/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.component.html
@@ -1,0 +1,20 @@
+<p>
+  Search has been updated to keep the model up to date with each character entered
+by a user. As a result, <code>(modelChange)</code> can no longer be used to
+detect that a user has clicked the submit button.
+</p>
+<p>
+  An output <code>(submit)</code> has been added to search which emits when the
+  user clicks submit. The value of the event contains the current state of the
+  model when the user clicks submit.
+</p>
+<p>
+  To supply a function which handles the <code>(submit)</code> output, pass a
+  function to the <code>submitHandler</code> field in <code>templateOptions</code>
+</p>
+
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form" (modelChange)="handleOnModelChange($event)"></formly-form>
+</form>
+
+{{model |json}}

--- a/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.component.ts
+++ b/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.component.ts
@@ -1,0 +1,77 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  templateUrl: './search-handle-submit.component.html',
+})
+
+export class SearchHandleSubmit {
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'filter',
+      templateOptions: {
+        label: 'Keyword (with label)',
+        ariaHidden: true
+      },
+      fieldGroup: [
+        {
+          key: 'searchmodel',
+          type: 'search',
+          templateOptions: {
+            label: 'Search',
+            submitHandler: this.handleSubmit
+          }
+        },
+
+        {
+          key: 'ddsearchmodel',
+          type: 'search',
+          templateOptions: {
+            label: 'Search with dropdown',
+            submitHandler: this.handleSubmit,
+            searchSettings: {
+              dropdown: {
+                options: [
+                  { label: '30 Days', value: '30' },
+                  { label: '60 Days', value: '60' },
+                  { label: '90 Days', value: '90' }
+                ]
+              }
+            }
+          }
+        },
+
+        {
+          key: 'invsearchmodel',
+          type: 'search',
+          templateOptions: {
+            label: 'Search with dropdown inverse',
+            submitHandler: this.handleSubmit,
+            searchSettings: {
+              dropdown: {
+                inverse: true,
+                options: [
+                  { label: '30 Days', value: '30' },
+                  { label: '60 Days', value: '60' },
+                  { label: '90 Days', value: '90' }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ];
+
+  handleOnModelChange(value){
+    console.log(value)
+  }
+  handleSubmit(value){
+    console.log('submitted', value)
+  }
+}

--- a/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.module.ts
+++ b/libs/documentation/src/lib/components/formly/search/demos/submit/search-handle-submit.module.ts
@@ -1,0 +1,15 @@
+
+import { FormlyModule } from '@ngx-formly/core';
+import { NgModule } from '@angular/core';
+import { SearchHandleSubmit } from './search-handle-submit.component';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
+  declarations: [SearchHandleSubmit],
+  exports: [SearchHandleSubmit],
+  bootstrap: [SearchHandleSubmit]
+})
+export class SearchHandleSubmitModule {}

--- a/libs/documentation/src/lib/components/formly/search/search.module.ts
+++ b/libs/documentation/src/lib/components/formly/search/search.module.ts
@@ -10,6 +10,8 @@ import { ComponentWrapperComponent } from '../../../shared/component-wrapper/com
 import { SearchBasicModule } from './demos/basic/search-basic.module';
 import { SearchOptionalModule } from './demos/optional/search-optional.module';
 import { SearchOptional } from './demos/optional/search-optional.component';
+import { SearchHandleSubmitModule } from './demos/submit/search-handle-submit.module';
+import { SearchHandleSubmit } from './demos/submit/search-handle-submit.component';
 
 declare var require: any;
 const DEMOS = {
@@ -26,6 +28,13 @@ const DEMOS = {
     code: require('!!raw-loader!./demos/optional/search-optional.component'),
     markup: require('!!raw-loader!./demos/optional/search-optional.component.html'),
     path: 'libs/documentation/src/lib/components/formly/search/demos/optional'
+  },
+  handleSubmit: {
+    title: 'Handling Submit',
+    type: SearchHandleSubmit,
+    code: require('!!raw-loader!./demos/submit/search-handle-submit.component'),
+    markup: require('!!raw-loader!./demos/submit/search-handle-submit.component.html'),
+    path: 'libs/documentation/src/lib/components/formly/search/demos/submit'
   }
 };
 
@@ -55,10 +64,11 @@ export const ROUTES = [
 
 @NgModule({
   imports: [
-    CommonModule, 
+    CommonModule,
     DocumentationComponentsSharedModule,
     SearchBasicModule,
-    SearchOptionalModule
+    SearchOptionalModule,
+    SearchHandleSubmitModule
   ]
 })
 export class FormlySearchModule {

--- a/libs/documentation/src/lib/components/search/demos/basic/search-basic.component.html
+++ b/libs/documentation/src/lib/components/search/demos/basic/search-basic.component.html
@@ -1,9 +1,19 @@
 <div>
+  <p>
+    Search has been updated to keep the model up to date with each character entered
+  by a user.
+  </p>
+  <p>
+    An output <code>(submit)</code> has been added to search which emits when the
+    user clicks submit. The value of the event contains the current state of the
+    model when the user clicks submit.
+  </p>
   <h4>SDS Search</h4>
 
   <sds-search
     [(ngModel)]="model"
     [searchSettings]="searchSettings"
+    (submit)="onSubmit($event)"
     placeholder="Entity an entity ID, name, or keyword"
   ></sds-search>
   Model: {{ model | json }}

--- a/libs/documentation/src/lib/components/search/demos/basic/search-basic.component.ts
+++ b/libs/documentation/src/lib/components/search/demos/basic/search-basic.component.ts
@@ -18,4 +18,8 @@ export class SearchBasic {
   onsearchModelChanges() {
     console.log(this.bigmodel, 'model changs');
   }
+
+  onSubmit(value){
+    console.log('Search Submitted', value)
+  }
 }

--- a/libs/packages/components/src/lib/search/search.component.html
+++ b/libs/packages/components/src/lib/search/search.component.html
@@ -1,7 +1,7 @@
 <form class="usa-form usa-search" [ngClass]="getClass()" role="search">
   <label class="usa-sr-only" for="options">Dropdown label</label>
   <select *ngIf="hasDropdown()" [value]="model.searchCategory? model.searchCategory :''" #selectEl name="search options"
-    class="usa-select" id="search-options">
+    class="usa-select" id="search-options" (change)="writeValueToModel()">
     <option [value]=""> {{searchSettings.dropdown.placeholder ? searchSettings.dropdown.placeholder : '-Select-'}}</option>
     <ng-container *ngFor="let item of searchSettings.dropdown.options">
       <optgroup *ngIf="item.group" label="{{item.label}}">
@@ -21,7 +21,7 @@
 <ng-template #inputTemplate>
   <label class="usa-sr-only" for="search-field">Search</label>
   <input #inputEl [value]="model.searchText? model.searchText :''" [ngClass]="inputClass" id="search-field" type="search" class="usa-input"
-    name="search" [placeholder]="searchSettings.placeholder? searchSettings.placeholder : 'type here'" (blur)="focusChange();"/>
+    name="search" [placeholder]="searchSettings.placeholder? searchSettings.placeholder : 'type here'" (blur)="focusChange();" (input)="writeValueToModel()"/>
   <button #buttonEl class="usa-button" type="submit"  (click)="handleClick($event)">
     <span class="usa-sr-only">Search</span>
   </button>

--- a/libs/packages/components/src/lib/search/search.component.ts
+++ b/libs/packages/components/src/lib/search/search.component.ts
@@ -6,7 +6,7 @@ import {
   AfterViewInit,
   forwardRef,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef, Output, EventEmitter
 } from '@angular/core';
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { ViewportRuler } from '@angular/cdk/overlay';
@@ -40,6 +40,8 @@ export class SdsSearchComponent implements AfterViewInit, ControlValueAccessor {
   @Input() inputClass: string;
   @Input() parentSelector: string;
   @Input() searchSettings: SearchSettings = new SearchSettings();
+
+  @Output() submit: EventEmitter<{searchText: string}> = new EventEmitter(null);
 
   model: any = {};
   inputState = {
@@ -82,11 +84,7 @@ export class SdsSearchComponent implements AfterViewInit, ControlValueAccessor {
       this.setInputVisibleStyles();
       this.focusMonitor.focusVia(this.inputEl, 'program');
     } else if (this.inputEl || this.selectEl) {
-      this.model.searchText = this.inputEl? this.inputEl.nativeElement.value : '';
-      if (this.selectEl && this.selectEl.nativeElement.value) {
-        this.model.searchCategory = this.selectEl.nativeElement.value;
-      }
-      this._onChange(this.model);
+      this.submit.emit(this.model);
     }
   }
 

--- a/libs/packages/components/src/lib/search/search.component.ts
+++ b/libs/packages/components/src/lib/search/search.component.ts
@@ -90,6 +90,14 @@ export class SdsSearchComponent implements AfterViewInit, ControlValueAccessor {
     }
   }
 
+  writeValueToModel() {
+    this.model.searchText = this.inputEl ? this.inputEl.nativeElement.value : '';
+    if (this.selectEl && this.selectEl.nativeElement.value) {
+      this.model.searchCategory = this.selectEl.nativeElement.value;
+    }
+    this._onChange(Object.assign({}, this.model));
+  }
+
   writeValue(value: any) {
     if (value && this.model !== value) {
       this.model = value;

--- a/libs/packages/components/src/lib/search/search.spec.ts
+++ b/libs/packages/components/src/lib/search/search.spec.ts
@@ -56,13 +56,13 @@ describe('SearchComponent', () => {
     expect(component.model.searchText).toBe(undefined);
   });
 
-  it('Should update the model value on click event', () => {
+  it('Should update the model value on input event', () => {
     const event = {
       preventDefault: () => {}
     };
     const input = fixture.debugElement.query(By.css('.usa-input'));
     input.nativeElement.value = 'test';
-    component.handleClick(event);
+    input.triggerEventHandler('input', {})
     expect(component.model.searchText).toBe('test');
   });
 

--- a/libs/packages/components/src/lib/search/search.spec.ts
+++ b/libs/packages/components/src/lib/search/search.spec.ts
@@ -66,6 +66,14 @@ describe('SearchComponent', () => {
     expect(component.model.searchText).toBe('test');
   });
 
+  it('Should emit on submit output on click event', () => {
+    const model = {searchText: 'abc'};
+    component.model = model;
+    spyOn(component.submit, 'emit');
+    component.handleClick({preventDefault: () => {}});
+    expect(component.submit.emit).toHaveBeenCalledWith(model)
+  });
+
   it('Should check the Initial State Visible', () => {
     expect(component.inputState.visible).toBe(
       component.inputState.initial.visible

--- a/libs/packages/sam-formly/src/lib/formly/types/search.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/search.ts
@@ -4,21 +4,20 @@ import {  Component,
     ChangeDetectorRef } from '@angular/core';
   import { AbstractSdsFormly } from '../sds-formly';
   import { SdsSearchComponent } from '@gsa-sam/components'
-  
+
   @Component({
     selector: 'sds-formly-field-search',
     template: `
-    <sds-search [formControl]="formControl"></sds-search>
+    <sds-search [formControl]="formControl" (submit)="to.submitHandler && to.submitHandler($event)"></sds-search>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
   })
   export class FormlyFieldSearchComponent extends AbstractSdsFormly {
-  
+
    @ViewChild(SdsSearchComponent) public template: SdsSearchComponent;
-  
+
     constructor (_cdr: ChangeDetectorRef) {
       super();
       this.cdr = _cdr;
     }
    }
-  


### PR DESCRIPTION
## Description
Updated search component to update model as user is typing rather than only when submit button is clicked. 

**NOTE: This will cause modelChange event on the formly component to fire with each keystroke. Therefore it is no longer possible to use this event as an indication that user has submitted. For an indication user has submitted make use of the submitHandler field detailed in the documentation**

Added submit event which is triggered when user clicks submit button. This event will include the value for search, but not the rest of the formly model. The event can be binded to using the submitHandler field in templateOptions.

Additionally added formly documentation to highlight the change and document how to use added features. Updated non-formly documentation to note the change and added output.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-44229
https://github.com/GSA/sam-design-system/issues/401

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [x] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="990" alt="Screen Shot 2020-12-02 at 10 20 35 AM" src="https://user-images.githubusercontent.com/72805180/100892287-2a9c1200-3488-11eb-8e60-d973cc8fa468.png">

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

