### PR TITLE
Resolve autocomplete issues with history url and disabled expressions

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
@@ -580,13 +580,11 @@ export class SDSAutocompleteSearchComponent implements ControlValueAccessor {
       this._changeDetectorRef.markForCheck();
       if (this.model.items.length === 0) {
         this.inputValue = '';
-      } else {
-        if (this.configuration.selectionMode === SelectionMode.SINGLE) {
+      } else if (this.configuration && this.configuration.selectionMode === SelectionMode.SINGLE){
           this.inputValue = this.getObjectValue(
             this.model.items[0],
             this.configuration.primaryTextField
           );
-        }
       }
     }
   }

--- a/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
@@ -101,6 +101,8 @@ export class SDSAutocompleteComponent implements ControlValueAccessor {
       this.model.items = value && value.items ? value.items : [];
       this.cd.markForCheck();
     }
+
+    this.autocompleteSearch.writeValue(this.model);
   }
 
   // Method that is fired when the child component event notifies us that the items array has been modified within the child component


### PR DESCRIPTION
## Description
Stems from github issue #387 and JIRA ticket https://cm-jira.usa.gov/browse/IAE-44006#. The changes here resolves two observed issues with single select autocomplete in sds-filters:
1. Upon refresh, when history is enabled, the autocomplete properly sets the data model based on url parameters, but does not update the UI with the proper values. As seen in image below, after refreshing, the data model is displaying the correct values based off url parameters, but those values are not reflected in the autocomplete inputs:
<img width="1672" alt="refresh-issue" src="https://user-images.githubusercontent.com/73653244/100935315-edeb0d80-34bd-11eb-913a-c34143d2fe22.png">

2. In the case when there are two auto-complete with the logic of second autocomplete being disabled until the value of first autocomplete is selected and the expectation that clearing out the first autocomplete form should clear the second as well, the data models for the two autocompletes are cleared out correctly, but the UI retains the text for the second autocomplete.
As seen in the screenshot, the data model displays empty values for both fields, but the UI retains the selected value of the disabled autocomplete input:
<img width="1679" alt="update-issue" src="https://user-images.githubusercontent.com/73653244/100935568-428e8880-34be-11eb-8ea0-fedb8148fce7.png">



## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

