### PR TITLE
Update demo to include disabled with expression properties

### DIFF
--- a/libs/documentation/src/lib/components/formly/autocomplete/demos/disable/autocomplete-disable.component.ts
+++ b/libs/documentation/src/lib/components/formly/autocomplete/demos/disable/autocomplete-disable.component.ts
@@ -26,7 +26,6 @@ export class FormlyAutocompleteDisable {
   };
   options: FormlyFormOptions = {};
   public settings = new SDSAutocompletelConfiguration();
-  public autocompleteSingleModel = new SDSSelectedItemModel();
   public autocompleteMultipleModel = new SDSSelectedItemModel();
   private data = SampleAutocompleteData;
   public filterChange$ = new BehaviorSubject<object>(null);

--- a/libs/documentation/src/lib/components/formly/autocomplete/demos/disable/autocomplete-disable.component.ts
+++ b/libs/documentation/src/lib/components/formly/autocomplete/demos/disable/autocomplete-disable.component.ts
@@ -20,12 +20,14 @@ export class FormlyAutocompleteDisable {
   model = {
     filters: {
       agency: [],
-      items: []
+      items1: [],
+      items2: []
     }
   };
   options: FormlyFormOptions = {};
   public settings = new SDSAutocompletelConfiguration();
-  public autocompleteModel = new SDSSelectedItemModel();
+  public autocompleteSingleModel = new SDSSelectedItemModel();
+  public autocompleteMultipleModel = new SDSSelectedItemModel();
   private data = SampleAutocompleteData;
   public filterChange$ = new BehaviorSubject<object>(null);
   public multipleSettings = new SDSAutocompletelConfiguration();
@@ -36,15 +38,35 @@ export class FormlyAutocompleteDisable {
       templateOptions: { label: 'Keyword' },
       fieldGroup: [
         {
-          key: 'items',
+          key: 'items1',
           type: 'autocomplete',
 
           templateOptions: {
-            label: 'Auto Complete disable with single selection mode',
-            disabled: true,
+            label: 'Generic Autocomplete',
             service: this.service,
             configuration: this.settings,
-            model: this.autocompleteModel
+          },
+          lifecycle: {
+            onChanges: function(form: FormGroup, field) {
+              form.controls.items1.valueChanges.subscribe((value: any[]) => {
+                if (!value || !value.length) {
+                  form.controls.items2.reset();
+                }
+              })
+            }
+          }
+        },
+        {
+          key: 'items2',
+          type: 'autocomplete',
+
+          templateOptions: {
+            label: 'Auto Complete disabled using Expression properties until Previous Autocomplete is selected',
+            service: this.service,
+            configuration: this.settings,
+          },
+          expressionProperties: {
+            'templateOptions.disabled': () => !this.model.filters.items1 || this.model.filters.items1.length === 0
           }
         },
         {
@@ -55,7 +77,7 @@ export class FormlyAutocompleteDisable {
             disabled: true,
             service: this.service,
             configuration: this.multipleSettings,
-            model: this.autocompleteModel
+            model: this.autocompleteMultipleModel
           }
         }
       ]
@@ -74,8 +96,6 @@ export class FormlyAutocompleteDisable {
     this.settings.labelText = 'Autocomplete 1';
     this.settings.selectionMode = SelectionMode.SINGLE;
     this.settings.autocompletePlaceHolderText = 'Enter text';
-
-    this.model.filters.items.push(this.data[0]);
 
     this.multipleSettings.id = 'autocomplete1';
     this.multipleSettings.primaryKeyField = 'id';


### PR DESCRIPTION
## Description
Our demo currently does not include conditional disable for autocomplete, so this PR modifies the demo for disabled autocomplete to use expression properties

## Motivation and Context
https://github.com/GSA/sam-design-system/issues/387

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ x ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

