### PR TITLE
Add selection panel to demo page

### DIFF
--- a/apps/sam-design-system-site/src/app/app.component.html
+++ b/apps/sam-design-system-site/src/app/app.component.html
@@ -166,6 +166,14 @@
                     Button Group
                   </a>
                 </li>
+                <li class="usa-sidenav__item">
+                  <a
+                    [routerLink]="['documentation/components/selection-panel']"
+                    routerLinkActive="usa-current"
+                  >
+                    Selection Panel
+                  </a>
+                </li>
               </ul>
             </li>
             <li class="margin-y-2">

--- a/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.component.html
+++ b/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.component.html
@@ -1,0 +1,8 @@
+
+  <sds-selection-panel 
+  [model]="selectionPanelModel"
+  [currentSelection]="selectionPanelModel.navigationLinks[1]"
+  [title]="title"
+  [navigateOnClick]="false"
+  (panelSelected)="onPanelSelection($event)">
+</sds-selection-panel>

--- a/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.component.ts
+++ b/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { NavigationLink, SideNavigationModel } from '@gsa-sam/components';
+import { selectionPanelConfig } from '../../navigation.config'
+
+@Component({
+  templateUrl: './basic-selection-panel.component.html',
+})
+export class BasicSelectionPanelComponent {
+
+  title = 'Basic Selection Panel'
+  selectionPanelModel: SideNavigationModel = selectionPanelConfig;
+
+  constructor() { }
+
+  onPanelSelection(panel: NavigationLink) {
+    console.log(panel);
+  }
+
+}

--- a/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.module.ts
+++ b/libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel/basic-selection-panel.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from '@angular/common';
+import { BasicSelectionPanelComponent } from './basic-selection-panel.component';
+import {
+  SdsSelectionPanelModule,
+} from '@gsa-sam/components';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SdsSelectionPanelModule,
+  ],
+  declarations: [
+    BasicSelectionPanelComponent,
+  ],
+  exports: [
+    BasicSelectionPanelComponent,
+  ],
+  bootstrap: [
+    BasicSelectionPanelComponent
+  ]
+})
+export class BasicSelectionPanelModule {}

--- a/libs/documentation/src/lib/components/selection-panel/navigation.config.ts
+++ b/libs/documentation/src/lib/components/selection-panel/navigation.config.ts
@@ -1,0 +1,48 @@
+import { SideNavigationModel, NavigationMode } from '@gsa-sam/components';
+
+export let selectionPanelConfig: SideNavigationModel = {
+     navigationLinks: [
+    {
+
+      text: 'All Domains', id: 'all', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'All Domains' }, mode: NavigationMode.INTERNAL, children: [
+        { text: 'Contract Opportunities', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Contract Opportunities' }, id: 'linkc1p1', mode: NavigationMode.INTERNAL },
+        {
+          text: 'Contract Data', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Contract Data'}, id: 'linkc2p1', mode: NavigationMode.INTERNAL
+        },
+        { text: 'Federal Assistance', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Federal Assistance' }, id: 'linkc3p1', mode: NavigationMode.INTERNAL },
+        {
+          text: 'Assistance Listings', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Assistance Listings' }, id: 'linkc4p1', mode: NavigationMode.INTERNAL
+          , children: [
+            {
+              text: 'Regional Locations', queryParams: { 'item': 'Regional Locations' }, route: '/documentation/components/sidenavigation/examples', id: 'linkgc2c4p1', mode: NavigationMode.INTERNAL,
+              children: [
+                { text: 'Entity Information', queryParams: { 'item': 'Entity Information' }, route: '/documentation/components/sidenavigation/examples', id: 'linkg1gc1c4p1', mode: NavigationMode.INTERNAL },
+                {
+                  text: 'Disaster Response Registry', queryParams: { 'item': 'Disaster Response Registry' }, route: '/documentation/components/sidenavigation/examples', id: 'linkg2gc1c4p1', mode: NavigationMode.INTERNAL
+                },
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      text: 'Exclusions', id: 'linkp2', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Exclusions' }, mode: NavigationMode.INTERNAL, children: [
+        {
+          text: 'Federal Hierarchy', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Federal Hierarchy' }, id: 'linkc1p2', mode: NavigationMode.INTERNAL, children: [
+
+            { text: 'Wage Determinations', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Wage Determinations' }, id: 'linkgc1c1p2', mode: NavigationMode.INTERNAL },
+          ]
+        },
+        { text: 'By Wage Determination ID', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'By Wage Determination ID' }, id: 'linkc2p2', mode: NavigationMode.INTERNAL },
+        { text: 'Construction (DBA)', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Construction (DBA)' }, id: 'linkc3p2', mode: NavigationMode.INTERNAL },
+        { text: 'Service Contracts (SCA)', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Service Contracts (SCA)' }, id: 'linkc4p2', mode: NavigationMode.INTERNAL },
+         { text: 'Collective Bargaining Agreements', route: '/documentation/components/sidenavigation/examples', queryParams: { 'item': 'Collective Bargaining Agreements' }, id: 'linkc5p2', mode: NavigationMode.INTERNAL }
+
+      ]
+    }
+    ]
+};
+
+
+

--- a/libs/documentation/src/lib/components/selection-panel/selection-panel.module.ts
+++ b/libs/documentation/src/lib/components/selection-panel/selection-panel.module.ts
@@ -1,0 +1,58 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ComponentWrapperComponent } from '../../shared/component-wrapper/component-wrapper.component';
+import { DocumentationComponentsSharedModule, DocumentationDemoList } from '../shared';
+import { DocumentationAPIPage } from '../shared/api-page/docs-api.component';
+import { DocumentationExamplesPage } from '../shared/examples-page/examples.component';
+import { DocumentationSourcePage } from '../shared/source-page/source.component';
+import { DocumentationTemplatePage } from '../shared/template-page/template.component';
+import { BasicSelectionPanelComponent } from './demos/basic-selection-panel/basic-selection-panel.component';
+import { BasicSelectionPanelModule } from './demos/basic-selection-panel/basic-selection-panel.module';
+
+
+declare var require: any;
+const DEMOS = {
+  optional: {
+    title: 'Basic Selection Panel',
+    type: BasicSelectionPanelComponent,
+    code: require('!!raw-loader!./demos/basic-selection-panel/basic-selection-panel.component'),
+    markup: require('!!raw-loader!./demos/basic-selection-panel/basic-selection-panel.component.html'),
+    path: 'libs/documentation/src/lib/components/selection-panel/demos/basic-selection-panel'
+  },
+};
+
+export const ROUTES = [
+  { path: '', pathMatch: 'full', redirectTo: 'examples' },
+  {
+    path: '',
+    component: ComponentWrapperComponent,
+    data: {
+      items: [
+        {
+          pkg: 'components',
+          type: 'components',
+          name: 'SdsSelectionPanelComponent'
+        }
+      ]
+    },
+    children: [
+      { path: 'examples', component: DocumentationExamplesPage },
+      { path: 'api', component: DocumentationAPIPage },
+      { path: 'source', component: DocumentationSourcePage },
+      { path: 'template', component: DocumentationTemplatePage }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    BasicSelectionPanelModule,
+  ]
+})
+export class SelectionPanelModule {
+  constructor(demoList: DocumentationDemoList) {
+    demoList.register('selection-panel', DEMOS);
+  }
+}

--- a/libs/documentation/src/lib/documentation.module.ts
+++ b/libs/documentation/src/lib/documentation.module.ts
@@ -74,6 +74,11 @@ import {
   FiltersModule
 } from './components/filters/filters.module';
 
+import {
+  ROUTES as SELECTION_PANEL_ROUTES,
+  SelectionPanelModule
+} from './components/selection-panel/selection-panel.module';
+
 /* Form Types */
 import {
   ROUTES as INPUT_ROUTES,
@@ -203,6 +208,7 @@ export const ROUTES: Routes = [
   { path: 'components/filters', children: FILTERS_ROUTES },
   { path: 'components/accordion', children: ACCORDION_ROUTES },
   { path: 'components/button-group', children: BUTTON_GROUP_ROUTES },
+  { path: 'components/selection-panel', children: SELECTION_PANEL_ROUTES},
 
   // Formly
   { path: 'components/input', children: INPUT_ROUTES },
@@ -287,7 +293,8 @@ export const ROUTES: Routes = [
     IconsModule,
     FormlyFormsModule,
     FormlyConditionalModule,
-    ButtonGroupModule
+    ButtonGroupModule,
+    SelectionPanelModule,
   ]
 })
 export class DocumentationModule {


### PR DESCRIPTION
Extension of the side-toolbar PR - Create demo page for the selection panel component. Relies on CSS from https://github.com/GSA/sam-styles/pull/372.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

