### PR TITLE
IAE-44578 Add check to ensure changeDetectorRef not destroyed

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/types/multicheckbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/multicheckbox.ts
@@ -27,7 +27,9 @@ export class FormlyFieldMultiCheckboxComponent extends FieldType
         (Array.isArray(values) && values.length) > 0 ? true : false;
       this.ariaChecked = isChecked.toString();
       this.allComplete = isChecked;
-      this.cdr.detectChanges();
+      if(!this.cdr['destroyed']){
+        this.cdr.detectChanges();
+      }
     });
     this.someComplete();
   }


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
Fix adds check that changeDetectorRef is not destroyed before calling it to avoid #435.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAE-44578
Addresses #435.

When view is switched, and changeDetectorRef is destroyed, the formControl is still throwing valueChange events leading to the error detailed in the issue. 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

