### PR TITLE
Add wrapper for formly readonly components

### DIFF
--- a/apps/sam-design-system-site/src/app/app.component.html
+++ b/apps/sam-design-system-site/src/app/app.component.html
@@ -358,6 +358,14 @@
                     Template Options
                   </a>
                 </li>
+                <li class="usa-sidenav__item">
+                  <a
+                    [routerLink]="['documentation/components/readonly']"
+                    routerLinkActive="usa-current"
+                  >
+                    Readonly
+                  </a>
+                </li>
               </ul>
             </li>
             <li class="margin-y-2">

--- a/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.component.html
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.component.html
@@ -1,0 +1,11 @@
+<p>
+  The default templates provided by <code>SdsReadonlyModule</code> might not be enough to handle some slightly more
+  complex requirements. You may also pass in your own custom html template that you would like to be displayed
+  while in readonly mode through the <code>readonlyTemplate</code> method in formly field's <code>templateOptions</code>
+</p>
+
+<form [formGroup]="form" class="margin-bottom-3">
+  <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
+</form>
+
+<button class="usa-button" (click)="toggleReadonlyMode()">Toggle Readonly Mode</button>

--- a/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.component.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.component.ts
@@ -1,0 +1,73 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyUtilsService, SdsFormlyTypes } from '@gsa-sam/sam-formly';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'gsa-sam-custom-template',
+  templateUrl: './custom-template.component.html',
+})
+export class CustomTemplateComponent {
+
+  isReadonlyMode = false;
+  form = new FormGroup({});
+  model = {};
+  fields: FormlyFieldConfig[] =  [
+    {
+      type: SdsFormlyTypes.READONLY,
+      templateOptions: {
+        readonlyTemplate: (field) => {
+          return `
+            <label class="usa-label">Phone Number</label>
+            <span class="text-bold">
+              ${field.model.countryCode ? field.model.countryCode : ''}
+              ${field.model.phoneNumber}
+              ${field.model.extension ? ' +' + field.model.extension : ''}
+            </span>
+          `;
+        }
+      },
+      hideExpression: () => !this.isReadonlyMode
+    },
+    {
+      fieldGroupClassName: 'grid-row grid-gap-2',
+      fieldGroup: [
+        {
+          className: 'grid-col-3',
+          key: 'countryCode',
+          type: SdsFormlyTypes.INPUT,
+          templateOptions: {
+            label: 'Country Code',
+            hideOptional: true,
+          },
+          hideExpression: () => this.isReadonlyMode,
+        },
+        {
+          className: 'grid-col-5',
+          key: 'phoneNumber',
+          type: SdsFormlyTypes.INPUT,
+          templateOptions: {
+            label: 'Phone',
+            hideOptional: true,
+          },
+          hideExpression: () => this.isReadonlyMode,
+        },
+        {
+          className: 'grid-col-3',
+          key: 'extension',
+          type: SdsFormlyTypes.INPUT,
+          templateOptions: {
+            label: 'Extension Number',
+            hideOptional: true,
+          },
+          hideExpression: () => this.isReadonlyMode,
+        },
+      ]
+    }
+  ];
+
+  toggleReadonlyMode() {
+    this.isReadonlyMode = !this.isReadonlyMode;
+    FormlyUtilsService.setReadonlyMode(this.isReadonlyMode, this.fields);
+  }
+}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.module.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/custom-template/custom-template.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { SdsFormlyModule } from "@gsa-sam/sam-formly";
+import { FormlyModule } from "@ngx-formly/core";
+import { CustomTemplateComponent } from "./custom-template.component";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SdsFormlyModule,
+    FormlyModule,
+    ReactiveFormsModule,
+  ],
+  declarations: [
+    CustomTemplateComponent,
+  ],
+  exports: [
+    CustomTemplateComponent
+  ],
+  bootstrap: [
+    CustomTemplateComponent
+  ]
+})
+export class CustomTemplateModule {}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.component.html
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.component.html
@@ -1,0 +1,52 @@
+<p>
+  You can enable a formly form to display in a readonly mode by switching the form's
+  <code>templateOption.readonlyMode</code> to true. In most cases, your form might
+  contain multiple formly fields, and would want to switch readonlyMode of all fields
+  on or off at the same time. This can be done through the 
+  <code>setReadonlyMode</code> method in <code>FormlyUtilsService</code> 
+  from <code>sam-formly</code> library.
+</p>
+
+<form [formGroup]="inpuyTypeform">
+  <formly-form [fields]="inputTypefields" [form]="inpuyTypeform"></formly-form>
+</form>
+
+<form [formGroup]="textareaTypeForm" class="margin-top-3">
+  <formly-form [fields]="textareaTypeFields" [form]="textareaTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="checkboxTypeForm" class="margin-top-3">
+  <formly-form [fields]="checkboxTypeFields" [form]="checkboxTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="datepickerTypeForm" class="margin-top-3">
+  <formly-form [fields]="datepickerTypeFields" [form]="datepickerTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="daterangePickerTypeForm" class="margin-top-3">
+  <formly-form [fields]="daterangePickerTypeFields" [form]="daterangePickerTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="fileinfoTypeForm" class="margin-top-3">
+  <formly-form [fields]="fileinfoTypeFields" [form]="fileinfoTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="multicheckboxTypeForm" class="margin-top-3">
+  <formly-form [fields]="multicheckboxTypeFields" [form]="multicheckboxTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="radioTypeForm" class="margin-top-3">
+  <formly-form [fields]="radioTypeFields" [form]="radioTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="selectTypeForm" class="margin-top-3">
+  <formly-form [fields]="selectTypeFields" [form]="selectTypeForm"></formly-form>
+</form>
+
+<form [formGroup]="autocompleteSingleSelectForm" class="margin-top-3">
+  <formly-form [fields]="autocompleteSingleSelectFields" [form]="autocompleteSingleSelectForm"></formly-form>
+</form>
+
+<form [formGroup]="autocompleteMultiSelectForm" class="margin-top-3">
+  <formly-form [fields]="autocompleteMultiSelectFields" [form]="autocompleteMultiSelectForm"></formly-form>
+</form>

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.component.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.component.ts
@@ -1,0 +1,404 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { SDSAutocompletelConfiguration, SDSSelectedItemModel, SelectionMode } from '@gsa-sam/components';
+import { FormlyUtilsService, SdsFormlyTypes } from '@gsa-sam/sam-formly';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { AutocompleteSampleDataService } from '../../../../autocomplete/demos/basic/service/autocomplete-sample.service';
+
+@Component({
+  selector: 'gsa-sam-readonly-basic',
+  templateUrl: './readonly-basic.component.html',
+  providers: [ AutocompleteSampleDataService ]
+
+})
+export class ReadonlyBasicComponent implements OnInit {
+
+  autocompleteSingleSelectSettings = new SDSAutocompletelConfiguration();
+  autocompleteMultiSelectSettings = new SDSAutocompletelConfiguration();
+
+  constructor(
+    private autocompleteSampleDataService: AutocompleteSampleDataService,
+  ) {}
+
+  readonlyModes =  {
+    inputType: false,
+    textareaType: false,
+    checkboxType: false,
+    datepickerType: false,
+    daterangepickerType: false,
+    fileinfoType: false,
+    multicheckboxType: false,
+    radioType: false,
+    selectType: false,
+    autocompleteSingleSelectType: false,
+    autocompleteMultiSelectType: false,
+  };
+
+  /**
+   * INPUT DEMO
+   */
+  inpuyTypeform = new FormGroup({});
+  inputTypefields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'input',
+      type: SdsFormlyTypes.INPUT,
+      defaultValue: 'Jane',
+      templateOptions: {
+        label: 'Input Type',
+        description: 'Enter text',
+        hideOptional: true,
+      },
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.inputType = !this.readonlyModes.inputType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.inputType, this.inputTypefields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * TEXTAREA DEMO
+   */
+  textareaTypeForm = new FormGroup({});
+  textareaTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'textareaText',
+      type: SdsFormlyTypes.TEXTAREA,
+      defaultValue: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut \
+      labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi \
+      ut aliquip ex ea commodo consequat.',
+      templateOptions: {
+        label: 'Textarea Type',
+        description: 'Enter text',
+        hideOptional: true,
+        rows: 6,
+      },
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.textareaType = !this.readonlyModes.textareaType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.textareaType, this.textareaTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * CHECKBOX DEMO
+   */
+  checkboxTypeForm = new FormGroup({});
+  checkboxTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'checkboxDemo',
+      type: SdsFormlyTypes.CHECKBOX,
+      defaultValue: true,
+      templateOptions: {
+        label: 'Checkbox',
+        description: 'Toggle Checkbox',
+        hideOptional: true,
+      },
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.checkboxType = !this.readonlyModes.checkboxType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.checkboxType, this.checkboxTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Datepicker Type
+   */
+  datepickerTypeForm = new FormGroup({});
+  datepickerTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'datepicker',
+      type: SdsFormlyTypes.DATEPICKER,
+      defaultValue: new Date(),
+      templateOptions: {
+        label: 'Datepicker Type',
+        description: 'Enter a date',
+        hideOptional: true,
+      },
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.datepickerType = !this.readonlyModes.datepickerType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.datepickerType, this.datepickerTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Datepicker Type
+   */
+  daterangePickerTypeForm = new FormGroup({});
+  daterangePickerTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'daterangepicker',
+      type: SdsFormlyTypes.DATERANGEPICKER,
+      defaultValue: new Date(),
+      templateOptions: {
+        label: 'Daterangepicker Type',
+        description: 'Enter a date range',
+        hideOptional: true,
+      },
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.daterangepickerType = !this.readonlyModes.daterangepickerType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.daterangepickerType, this.daterangePickerTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Fileinfo Type Demo
+   */
+  fileinfoTypeForm = new FormGroup({});
+  fileinfoTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'fileType',
+      type: SdsFormlyTypes.FILEINFO,
+      templateOptions: {
+        label: 'Select file type',
+        hideOptional: true,
+        options: [
+          { value: 'Default', key: 'CSV', description: '-Limited to 5000' },
+          { value: 'Full', key: 'ZIP', description: '-Limited to 10,000' },
+          { value: 'Case', key: 'PDF', description: '-Limited to 8000' },
+          { value: 'All', key: 'XLS', description: '-Limited to 45000' }
+        ]
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.fileinfoType = !this.readonlyModes.fileinfoType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.fileinfoType, this.fileinfoTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Multicheckbox demo
+   */
+  multicheckboxTypeForm = new FormGroup({});
+  multicheckboxTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'multicheckbox',
+      type: SdsFormlyTypes.MULTICHECKBOX,
+      templateOptions: {
+        label: 'Select From Multiple Checkboxes',
+        description: 'Choose desired toppings',
+        hideOptional: true,
+        options: [
+          { key: 'tomato', value: 'Tomato'},
+          { key: 'onion', value: 'Onion'},
+          { key: 'pickles', value: 'Pickles'},
+          { key: 'lettuce', value: 'Lettuce'},
+        ]
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.multicheckboxType = !this.readonlyModes.multicheckboxType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.multicheckboxType, this.multicheckboxTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Radio Demo
+   */
+  radioTypeForm = new FormGroup({});
+  radioTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'radioType',
+      type: SdsFormlyTypes.RADIO,
+      templateOptions: {
+        label: 'Select From Radio Options',
+        description: 'Choose a radio option',
+        hideOptional: true,
+        options: [
+          { key: 'optiona', value: 'Option A'},
+          { key: 'optionb', value: 'Option B'},
+          { key: 'optionc', value: 'Option C'},
+        ]
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.radioType = !this.readonlyModes.radioType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.radioType, this.radioTypeFields);
+        },
+      }
+    }
+  ];
+
+  /**
+   * Select Demo
+   */
+  selectTypeForm = new FormGroup({});
+  selectTypeFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'selectType',
+      type: SdsFormlyTypes.SELECT,
+      defaultValue: 'Select',
+      templateOptions: {
+        label: 'Select From Provided Options',
+        description: 'Choose a state',
+        hideOptional: true,
+        options: [
+          { id: '0', label: '--Select--', value: 'Select' },
+          { id: '1', label: 'Alabama', value: 'Alabama' },
+          { id: '2', label: 'Alaska', value: 'Alaska' },
+          { id: '3', label: 'Arizona', value: 'Arizona' },
+          { id: '4', label: 'Arkansas', value: 'Arkansas' },
+          { id: '5', label: 'California', value: 'California' },
+        ]
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.selectType = !this.readonlyModes.selectType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.selectType, this.selectTypeFields);
+        },
+      }
+    }
+  ];
+
+
+  /**
+   * Autocomplete Single Select Demo
+   */
+  autocompleteSingleSelectForm = new FormGroup({});
+  autocompleteSingleSelectFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'autocompleteSingle',
+      type: SdsFormlyTypes.AUTOCOMPLETE,
+      templateOptions: {
+        label: 'Single Select Autocomplete',
+        description: 'Select an item',
+        hideOptional: true,
+        configuration: this.autocompleteSingleSelectSettings,
+        service: this.autocompleteSampleDataService,
+        model: new SDSSelectedItemModel(),
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.autocompleteSingleSelectType = !this.readonlyModes.autocompleteSingleSelectType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.autocompleteSingleSelectType, this.autocompleteSingleSelectFields);
+        },
+      }
+    }
+  ];
+
+    /**
+   * Autocomplete Multi-Select Demo
+   */
+  autocompleteMultiSelectForm = new FormGroup({});
+  autocompleteMultiSelectFields: FormlyFieldConfig[] = [
+    {
+      className: 'grid-col-7 display-inline-block',
+      key: 'autocompleteMulti',
+      type: SdsFormlyTypes.AUTOCOMPLETE,
+      templateOptions: {
+        label: 'Multi Select Autocomplete',
+        description: 'Select items',
+        hideOptional: true,
+        configuration: this.autocompleteMultiSelectSettings,
+        service: this.autocompleteSampleDataService,
+        model: new SDSSelectedItemModel(),
+      }
+    },
+    {
+      className: 'display-inline-flex margin-left-4',
+      type: SdsFormlyTypes.BUTTON,
+      templateOptions: {
+        text: 'Toggle Readonly',
+        onClick: () => {
+          this.readonlyModes.autocompleteMultiSelectType = !this.readonlyModes.autocompleteMultiSelectType;
+          FormlyUtilsService.setReadonlyMode(this.readonlyModes.autocompleteMultiSelectType, this.autocompleteMultiSelectFields);
+        },
+      }
+    }
+  ];
+
+  ngOnInit() {
+    this.autocompleteSingleSelectSettings.id = 'autocompletesingle';
+    this.autocompleteSingleSelectSettings.primaryKeyField = 'id';
+    this.autocompleteSingleSelectSettings.primaryTextField = 'name';
+    this.autocompleteSingleSelectSettings.secondaryTextField = 'subtext';
+    this.autocompleteSingleSelectSettings.labelText = 'Autocomplete Single Select';
+    this.autocompleteSingleSelectSettings.selectionMode = SelectionMode.SINGLE;
+    this.autocompleteSingleSelectSettings.autocompletePlaceHolderText = 'Enter text';
+    this.autocompleteSingleSelectSettings.isFreeTextEnabled = true;
+
+    this.autocompleteMultiSelectSettings.id = 'autocompletesingle';
+    this.autocompleteMultiSelectSettings.primaryKeyField = 'id';
+    this.autocompleteMultiSelectSettings.primaryTextField = 'name';
+    this.autocompleteMultiSelectSettings.secondaryTextField = 'subtext';
+    this.autocompleteMultiSelectSettings.labelText = 'Autocomplete Single Select';
+    this.autocompleteMultiSelectSettings.selectionMode = SelectionMode.MULTIPLE;
+    this.autocompleteMultiSelectSettings.autocompletePlaceHolderText = 'Enter text';
+    this.autocompleteMultiSelectSettings.isFreeTextEnabled = true;
+  }
+}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.module.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic/readonly-basic.module.ts
@@ -1,0 +1,14 @@
+import { FormlyModule } from '@ngx-formly/core';
+import { NgModule } from '@angular/core';
+import { ReadonlyBasicComponent } from './readonly-basic.component';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
+  declarations: [ReadonlyBasicComponent],
+  exports: [ReadonlyBasicComponent],
+  bootstrap: [ReadonlyBasicComponent]
+})
+export class ReadonlyBasicModule {} 

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly-type.component.html
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly-type.component.html
@@ -1,0 +1,15 @@
+<p>
+  In the formly field config, you may also define a formly field as having a readonly type. In that case,
+  the readonly wrapper will be used and the field will stay in readonly mode, ignoring the switch done 
+  from <code>FormlyUtilsService</code> method
+</p>
+
+<form [formGroup]="form" class="margin-bottom-3">
+  <formly-form [fields]="fields" [form]="form"></formly-form>
+</form>
+
+<button *ngIf="!isReadOnlyMode; else readonlyMode" class="usa-button" (click)="toggleReadonlyMode()">Preview</button>
+
+<ng-template #readonlyMode>
+  <button *ngIf="isReadOnlyMode; else readonlyMode" class="usa-button usa-button--base" (click)="toggleReadonlyMode()">Cancel</button>
+</ng-template>

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly-type.component.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly-type.component.ts
@@ -1,0 +1,62 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyUtilsService, SdsFormlyTypes } from '@gsa-sam/sam-formly';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'gsa-sam-readonly-formly-type',
+  templateUrl: './readonly-formly-type.component.html',
+})
+export class ReadonlyFormlyTypeComponent {
+
+  isReadOnlyMode = false;
+
+  form = new FormGroup({});
+  fields: FormlyFieldConfig[] = [
+    {
+      template: `<span class="text-error sds-small text-italic">
+        *Due to techinical difficulties, we are currently only allowing payment through credit
+        </span>`
+    },
+    {
+      type: SdsFormlyTypes.READONLY,
+      defaultValue: 'Credit',
+      templateOptions: {
+        label: 'Payment Type',
+        hideOptional: true,
+      },
+    },
+    {
+      type: SdsFormlyTypes.INPUT,
+      templateOptions: {
+        label: 'Card Number',
+        placeholder: '16-digit Credit Card Number',
+        required: true,
+        maxLength: 16,
+      },
+    },
+    {
+      type: SdsFormlyTypes.INPUT,
+      templateOptions: {
+        label: 'Security Code',
+        placeholder: '3 or 4 digit CVV',
+        required: true,
+        maxLength: 4,
+      },
+    },
+    {
+      type: SdsFormlyTypes.INPUT,
+      templateOptions: {
+        label: 'Zip Code',
+        placeholder: '5 digit Zip Code',
+        required: true,
+        maxLength: 5
+      },
+    },
+  ]
+
+  toggleReadonlyMode() {
+    this.isReadOnlyMode = !this.isReadOnlyMode
+    FormlyUtilsService.setReadonlyMode(this.isReadOnlyMode, this.fields);
+  }
+}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly.module.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type/readonly-formly.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { SdsFormlyModule } from "@gsa-sam/sam-formly";
+import { FormlyModule } from "@ngx-formly/core";
+import { ReadonlyFormlyTypeComponent } from "./readonly-formly-type.component";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SdsFormlyModule,
+    FormlyModule,
+    ReactiveFormsModule,
+  ],
+  declarations: [
+    ReadonlyFormlyTypeComponent,
+  ],
+  exports: [
+    ReadonlyFormlyTypeComponent
+  ],
+  bootstrap: [
+    ReadonlyFormlyTypeComponent
+  ]
+})
+export class ReadonlyFormlyTypeModule{}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.component.html
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.component.html
@@ -1,0 +1,17 @@
+<p>
+  The readonly wrapper internally unses default templates wrapped in <code>ReadonlyContainerComponent</code>.
+  Thus you may also choose to not use formly and directly pass in the required inputs to this wrapper component
+  to display your date model
+</p>
+<div class="grid-row grid-gap-2">
+  <ng-container *ngFor="let data of sampleData">
+    <sds-readonly-container
+      class="grid-col-4"
+      [formlyType]="data.formlyType"
+      [label]="data.label" 
+      [value]="data.value" 
+      [additionalConfig]="data.additionalConfig">
+    </sds-readonly-container>
+  </ng-container>
+</div>
+

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.component.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { SdsFormlyTypes } from '@gsa-sam/sam-formly';
+
+@Component({
+  selector: 'gsa-sam-readonly-wrapper',
+  templateUrl: './readonly-wrapper.component.html',
+})
+export class ReadonlyWrapperComponent {
+
+  sampleData = [
+    {
+      formlyType: SdsFormlyTypes.INPUT,
+      label: 'First Name',
+      value: 'Jane'
+    },
+    {
+      formlyType: SdsFormlyTypes.CHECKBOX,
+      label: 'Checkbox Label',
+      value: true
+    },
+    {
+      formlyType: SdsFormlyTypes.SELECT,
+      label: 'Selected State',
+      value: 'virginia',
+      additionalConfig: {
+        providedOptions: [
+          {value: 'arizona', label: 'Arizona'},
+          {value: 'michigan', label: 'Michigan'},
+          {value: 'virginia', label: 'Virginia'},
+          {value: 'florida', label: 'Florida'}
+        ]
+      }
+    },
+    {
+      formlyType: SdsFormlyTypes.AUTOCOMPLETE,
+      label: 'Autocomplete Label',
+      value: [
+        {id: 1, name: 'Jane', email: 'jane_doe@mail.com'},
+        {id: 4, name: 'John', email: 'john_doe@mail.com'}
+      ],
+      additionalConfig: {
+        autocompleteOptions: {
+          primaryTextField: 'name'
+        }
+      }
+    },
+  ]
+}

--- a/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.module.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper/readonly-wrapper.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { SdsReadonlyModule } from "@gsa-sam/sam-formly";
+import { ReadonlyWrapperComponent } from "./readonly-wrapper.component";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SdsReadonlyModule,
+  ],
+  declarations: [
+    ReadonlyWrapperComponent
+  ],
+  exports: [
+    ReadonlyWrapperComponent
+  ],
+  bootstrap: [
+    ReadonlyWrapperComponent
+  ]
+})
+export class ReadonlyWrapperModule {}

--- a/libs/documentation/src/lib/components/formly/readonly/readonly.module.ts
+++ b/libs/documentation/src/lib/components/formly/readonly/readonly.module.ts
@@ -1,0 +1,88 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DocumentationExamplesPage } from '../../shared/examples-page/examples.component';
+import { DocumentationAPIPage } from '../../shared/api-page/docs-api.component';
+import { DocumentationSourcePage } from '../../shared/source-page/source.component';
+import { DocumentationTemplatePage } from '../../shared/template-page/template.component';
+import { DocumentationComponentsSharedModule, DocumentationDemoList } from '../../shared/index';
+import { ComponentWrapperComponent } from '../../../shared/component-wrapper/component-wrapper.component';
+import { ReadonlyBasicComponent } from './demos/readonly-basic/readonly-basic.component';
+import { ReadonlyBasicModule } from './demos/readonly-basic/readonly-basic.module';
+import { ReadonlyWrapperComponent } from './demos/readonly-wrapper/readonly-wrapper.component';
+import { ReadonlyWrapperModule } from './demos/readonly-wrapper/readonly-wrapper.module';
+import { ReadonlyFormlyTypeModule } from './demos/readonly-formly-type/readonly-formly.module';
+import { ReadonlyFormlyTypeComponent } from './demos/readonly-formly-type/readonly-formly-type.component';
+import { CustomTemplateComponent } from './demos/custom-template/custom-template.component';
+import { CustomTemplateModule } from './demos/custom-template/custom-template.module';
+
+declare var require: any;
+const DEMOS = {
+  basic: {
+    title: 'Basic Form Readonly',
+    type: ReadonlyBasicComponent,
+    code: require('!!raw-loader!./demos/readonly-basic/readonly-basic.component'),
+    markup: require('!!raw-loader!./demos/readonly-basic/readonly-basic.component.html'),
+    path: 'libs/documentation/src/lib/components/formly/readonly/demos/readonly-basic'
+  },
+  readonlyContainer: {
+    title: 'Readonly Without Formly',
+    type: ReadonlyWrapperComponent,
+    code: require('!!raw-loader!./demos/readonly-wrapper/readonly-wrapper.component'),
+    markup: require('!!raw-loader!./demos/readonly-wrapper/readonly-wrapper.component.html'),
+    path: 'libs/documentation/src/lib/components/formly/readonly/demos/readonly-wrapper'
+  },
+  readonlyFormlyType: {
+    title: 'Readonly as Formly Type',
+    type: ReadonlyFormlyTypeComponent,
+    code: require('!!raw-loader!./demos/readonly-formly-type/readonly-formly-type.component'),
+    markup: require('!!raw-loader!./demos/readonly-formly-type/readonly-formly-type.component.html'),
+    path: 'libs/documentation/src/lib/components/formly/readonly/demos/readonly-formly-type'
+  },
+  readonlyCustomTemplates: {
+    title: 'Readonly Custom Templates',
+    type: CustomTemplateComponent,
+    code: require('!!raw-loader!./demos/custom-template/custom-template.component'),
+    markup: require('!!raw-loader!./demos/custom-template/custom-template.component.html'),
+    path: 'libs/documentation/src/lib/components/formly/readonly/demos/custom-template'
+  },
+};
+
+export const ROUTES = [
+  { path: '', pathMatch: 'full', redirectTo: 'examples' },
+  {
+    path: '',
+    data: {
+      items: [
+        {
+          pkg: 'formly',
+          type: 'components',
+          name: 'FormlyReadonlyWrapperComponent',
+          wrappers: ['readonly'],
+        }
+      ]
+    },
+    component: ComponentWrapperComponent,
+    children: [
+      { path: 'examples', component: DocumentationExamplesPage },
+      { path: 'api', component: DocumentationAPIPage },
+      { path: 'source', component: DocumentationSourcePage },
+      { path: 'template', component: DocumentationTemplatePage },
+    ]
+  }
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    ReadonlyBasicModule,
+    ReadonlyWrapperModule,
+    ReadonlyFormlyTypeModule,
+    CustomTemplateModule,
+  ]
+})
+export class ReadonlyModule {
+  constructor(demoList: DocumentationDemoList) {
+    demoList.register('readonly', DEMOS);
+  }
+}

--- a/libs/documentation/src/lib/documentation.module.ts
+++ b/libs/documentation/src/lib/documentation.module.ts
@@ -163,6 +163,10 @@ import {
   ROUTES as BUTTON_GROUP_ROUTES,
   ButtonGroupModule
 } from './components/button-group/button-group.module';
+import {
+  ROUTES as READONLY_ROUTES,
+  ReadonlyModule
+} from './components/formly/readonly/readonly.module';
 
 /* Utilities */
 import {
@@ -240,6 +244,7 @@ export const ROUTES: Routes = [
   { path: 'components/description', children: DESCRIPTION_ROUTES },
   { path: 'components/validation', children: VALIDATION_ROUTES },
   { path: 'components/templateoptions', children: TEMPLATEOPTIONS_ROUTES },
+  { path: 'components/readonly', children: READONLY_ROUTES },
 
   // Form Examples
   { path: 'pages', pathMatch: 'full', redirectTo: 'pages/formly-form' },
@@ -302,6 +307,7 @@ export const ROUTES: Routes = [
     ButtonGroupModule,
     SelectionPanelModule,
     SystemAlertsModule,
+    ReadonlyModule,
   ],
 })
 export class DocumentationModule {

--- a/libs/packages/sam-formly/src/lib/formly/formly.config.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.config.ts
@@ -45,6 +45,7 @@ import { FormlyValidationWrapperComponent } from './wrappers/validation.wrapper'
 import { FormlyGroupWrapperComponent } from './wrappers/group.wrapper';
 import { FormlyFieldSearchComponent } from './types/search';
 import { FormlyFieldFileInfoComponent } from './types/fileinfo';
+import { SdsFormlyTypes } from './models/formly-types';
 
 export const FORMLY_WRAPPERS: any = [
   {
@@ -94,60 +95,60 @@ export const FORMLY_WRAPPERS: any = [
 export const FORMLY_CONFIG: ConfigOption = {
   types: [
     {
-      name: 'formly-group',
+      name: SdsFormlyTypes.FORMLYGROUP,
       wrappers: sdsGroupWrapper
     },
     {
-      name: 'button',
+      name: SdsFormlyTypes.BUTTON,
       component: FormlyFieldButtonComponent
     },
     {
-      name: 'customtext',
+      name: SdsFormlyTypes.CUSTOMTEXT,
       component: FormlyFieldTextComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'input',
+      name: SdsFormlyTypes.INPUT,
       component: FormlyFieldInputComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'checkbox',
+      name: SdsFormlyTypes.CHECKBOX,
       component: FormlyFieldCheckboxComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'fileinfo',
+      name: SdsFormlyTypes.FILEINFO,
       component: FormlyFieldFileInfoComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'radio',
+      name: SdsFormlyTypes.RADIO,
       component: FormlyFieldRadioComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'select',
+      name: SdsFormlyTypes.SELECT,
       component: FormlyFieldSelectComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'textarea',
+      name: SdsFormlyTypes.TEXTAREA,
       component: FormlyFieldTextAreaComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'multicheckbox',
+      name: SdsFormlyTypes.MULTICHECKBOX,
       component: FormlyFieldMultiCheckboxComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'autocomplete',
+      name: SdsFormlyTypes.AUTOCOMPLETE,
       component: FormlyFieldAutoCompleteComponent,
       wrappers: sdsWrappers
     },
     {
-      name: 'datepicker',
+      name: SdsFormlyTypes.DATEPICKER,
       component: FormlyFieldDatePickerComponent,
       wrappers: sdsWrappers,
       defaultOptions: {
@@ -157,13 +158,13 @@ export const FORMLY_CONFIG: ConfigOption = {
       }
     },
     {
-      name: 'daterangepicker',
-      extends: 'formly-group',
+      name : SdsFormlyTypes . DATERANGEPICKER ,
+      extends: SdsFormlyTypes.FORMLYGROUP,
       wrappers: sdsWrappers,
       defaultOptions: {
         fieldGroup: [
           {
-            type: 'datepicker',
+            type: SdsFormlyTypes.DATEPICKER,
             key: 'fromDate',
             templateOptions: {
               label: 'From'
@@ -174,7 +175,7 @@ export const FORMLY_CONFIG: ConfigOption = {
             }
           },
           {
-            type: 'datepicker',
+            type: SdsFormlyTypes.DATEPICKER,
             key: 'toDate',
             templateOptions: {
               label: 'To'
@@ -188,7 +189,7 @@ export const FORMLY_CONFIG: ConfigOption = {
       }
     },
     {
-      name: 'search',
+      name: SdsFormlyTypes.SEARCH,
       component: FormlyFieldSearchComponent,
       wrappers: sdsWrappers
     }

--- a/libs/packages/sam-formly/src/lib/formly/formly.config.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.config.ts
@@ -35,7 +35,8 @@ export const FIELD_TYPE_COMPONENTS = [
   FormlyValidationWrapperComponent,
   FormlyFieldTextComponent,
   FormlyGroupWrapperComponent,
-  FormlyFieldSearchComponent
+  FormlyFieldSearchComponent,
+  FormlyReadonlyWrapperComponent,
 ];
 import { maxDateValidator, minDateValidator } from './formly.validators';
 import { sdsWrappers, sdsGroupWrapper } from './sds-formly-options';
@@ -46,6 +47,7 @@ import { FormlyGroupWrapperComponent } from './wrappers/group.wrapper';
 import { FormlyFieldSearchComponent } from './types/search';
 import { FormlyFieldFileInfoComponent } from './types/fileinfo';
 import { SdsFormlyTypes } from './models/formly-types';
+import { FormlyReadonlyWrapperComponent } from './wrappers/readonly.wrapper';
 
 export const FORMLY_WRAPPERS: any = [
   {
@@ -89,6 +91,11 @@ export const FORMLY_WRAPPERS: any = [
     name: 'customwrapper',
     component: FormlyCustomWrapperComponent,
     componentName: 'FormlyCustomWrapperComponent'
+  },
+  {
+    name: 'readonly',
+    component: FormlyReadonlyWrapperComponent,
+    componentName: 'FormlyReadonlyWrapperComponent',
   }
 ];
 
@@ -97,6 +104,11 @@ export const FORMLY_CONFIG: ConfigOption = {
     {
       name: SdsFormlyTypes.FORMLYGROUP,
       wrappers: sdsGroupWrapper
+    },
+    {
+      name: SdsFormlyTypes.READONLY,
+      wrappers: sdsGroupWrapper,
+      component: FormlyReadonlyWrapperComponent,
     },
     {
       name: SdsFormlyTypes.BUTTON,
@@ -202,7 +214,8 @@ export const FORMLY_CONFIG: ConfigOption = {
     { name: 'form-field', component: FormlyWrapperFormFieldComponent },
     { name: 'accordionwrapper', component: FormlyAccordianFormFieldComponent },
     { name: 'filterwrapper', component: FormlyFormFieldFilterWrapperComponent },
-    { name: 'customwrapper', component: FormlyCustomWrapperComponent }
+    { name: 'customwrapper', component: FormlyCustomWrapperComponent },
+    { name: 'readonly', component: FormlyReadonlyWrapperComponent },
   ]
 };
 

--- a/libs/packages/sam-formly/src/lib/formly/formly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.module.ts
@@ -14,6 +14,7 @@ import {
 import { FIELD_TYPE_COMPONENTS, FORMLY_CONFIG } from './formly.config';
 import { maxDateValidator, minDateValidator } from './formly.validators';
 import { AnimationWrapperComponent } from './wrappers/form-field.animation';
+import { SdsReadonlyModule } from './readonly/readonly.module';
 
 // Validate the min length of the character
 export function minlengthValidationMessage(err, field) {
@@ -88,6 +89,7 @@ export { maxDateValidator, minDateValidator } from './formly.validators';
     FontAwesomeModule,
     ReactiveFormsModule,
     FormlySelectModule,
+    SdsReadonlyModule,
     FormlyModule.forChild(FORMLY_CONFIG),
     FormlyModule.forRoot({
       validationMessages: [

--- a/libs/packages/sam-formly/src/lib/formly/models/formly-types.ts
+++ b/libs/packages/sam-formly/src/lib/formly/models/formly-types.ts
@@ -1,0 +1,17 @@
+export enum SdsFormlyTypes {
+  INPUT = 'input',
+  BUTTON = 'button',
+  CHECKBOX = 'checkbox',
+  MULTICHECKBOX = 'multicheckbox',
+  RADIO = 'radio',
+  AUTOCOMPLETE = 'autocomplete',
+  DATEPICKER = 'datepicker',
+  SELECT = 'select',
+  TEXTAREA = 'textarea',
+  READONLY = 'readonly',
+  DATERANGEPICKER = 'daterangepicker',
+  FORMLYGROUP = 'formly-group',
+  CUSTOMTEXT = 'customtext',
+  FILEINFO = 'fileinfo',
+  SEARCH = 'search',
+};

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.html
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.html
@@ -1,0 +1,13 @@
+<span [ngSwitch]="formlyType">
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.INPUT" [label]="label" [value]="value"></sds-readonly-input>
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.TEXTAREA" [label]="label" [value]="value"></sds-readonly-input>
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.READONLY" [label]="label" [value]="value"></sds-readonly-input>
+  <sds-readonly-datepicker *ngSwitchCase="sdsFormlyTypes.DATEPICKER" [label]="label" [value]="value"></sds-readonly-datepicker>
+  <sds-readonly-select *ngSwitchCase="sdsFormlyTypes.SELECT" [label]="label" [value]="value" [selectOptions]="additionalConfig.providedOptions"></sds-readonly-select>
+  <sds-readonly-radio *ngSwitchCase="sdsFormlyTypes.RADIO" [label]="label" [value]="value" [radioOptions]="additionalConfig.providedOptions"></sds-readonly-radio>
+  <sds-readonly-fileinfo *ngSwitchCase="sdsFormlyTypes.FILEINFO" [label]="label" [value]="value" [fileInfoOptions]="additionalConfig.providedOptions"></sds-readonly-fileinfo>
+  <sds-readonly-autocomplete *ngSwitchCase="sdsFormlyTypes.AUTOCOMPLETE" [label]="label" [value]="value" [autocompleteSettings]="additionalConfig.autocompleteOptions"></sds-readonly-autocomplete>
+  <sds-readonly-checkbox *ngSwitchCase="sdsFormlyTypes.CHECKBOX" [label]="label" [value]="value"></sds-readonly-checkbox>
+  <sds-readonly-multicheckbox *ngSwitchCase="sdsFormlyTypes.MULTICHECKBOX" [label]="label" [value]="value" [multicheckboxOptions]="additionalConfig.providedOptions"></sds-readonly-multicheckbox>
+  <sds-readonly-daterange *ngSwitchCase="sdsFormlyTypes.DATERANGEPICKER" [label]="label" [value]="value" [daterangepickerOptions]="additionalConfig.daterangepickerOptions"></sds-readonly-daterange>
+</span> 

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
@@ -1,0 +1,70 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { SdsFormlyTypes } from "../models/formly-types";
+import { ReadonlyOptions } from './readonly-options.model';
+
+/**
+ * Wrapper level component for displaying readonly format for each formly types
+ */
+@Component({
+  selector: `sds-readonly-container`,
+  templateUrl: './readonly-container.component.html',
+})
+export class ReadonlyContainerComponent implements OnInit {
+
+  /**
+   * Formlyfieldconfig that is used to generate the formlyform. If this value
+   * is provided, the necessary information will be extracted from the given
+   * field configuration, and all other inputs will be ignored.
+   */
+  @Input() formlyFieldConfig: FormlyFieldConfig;
+
+  /**
+   * Type of formly to display value for - will be ignored if formlyFieldConfig is defined
+   */
+  @Input() formlyType: string;
+
+  /**
+   * Label for the given value - will be ignored if formlyFieldConfig input is defined
+   * */
+  @Input() label: string;
+
+  /**
+   * Value of corresponding label - will be ignored if formlyFieldConfig is defined
+   */
+  @Input() value: any;
+
+  /**
+   * Additional information useful for displaying the value - will be ignored if formlyFieldConfig is defined
+   */
+  @Input() additionalConfig: ReadonlyOptions = {};
+
+
+  sdsFormlyTypes = SdsFormlyTypes;
+
+  ngOnInit() {
+    if (this.formlyFieldConfig) {
+      this.label = this.formlyFieldConfig.templateOptions.label;
+      this.value = this.formlyFieldConfig.formControl.value;
+      this.formlyType = this.formlyFieldConfig.type;
+      this.assignAdditionalConfig();
+    }
+  }
+
+  private assignAdditionalConfig() {
+    const options = this.formlyFieldConfig.templateOptions.options as any;
+    this.additionalConfig = {
+      providedOptions: options,
+      autocompleteOptions: this.formlyFieldConfig.templateOptions.configuration,
+    };
+
+    // We do array access from field config for daterangepicker, which can be undefined for other types, 
+    // hence this is sectioned off in a conditional
+    if (this.formlyFieldConfig.type === this.sdsFormlyTypes.DATERANGEPICKER) {
+      this.additionalConfig.daterangepickerOptions = {
+        fromDateKey: this.formlyFieldConfig.fieldGroup[0].key as any,
+        toDateKey: this.formlyFieldConfig.fieldGroup[1].key as any,
+      }
+    }
+  }
+} 

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
@@ -55,8 +55,11 @@ export class ReadonlyContainerComponent implements OnInit {
     const options = this.formlyFieldConfig.templateOptions.options as any;
     this.additionalConfig = {
       providedOptions: options,
-      autocompleteOptions: this.formlyFieldConfig.templateOptions.configuration,
     };
+
+    if (this.formlyFieldConfig.type === this.sdsFormlyTypes.AUTOCOMPLETE) {
+      this.additionalConfig.autocompleteOptions = this.formlyFieldConfig.templateOptions.configuration;
+    }
 
     // We do array access from field config for daterangepicker, which can be undefined for other types, 
     // hence this is sectioned off in a conditional

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-options.model.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-options.model.ts
@@ -1,0 +1,26 @@
+/**
+ * Contains additional options needed to properly render some formly types. In some cases,
+ * just label and value might not be enough, and will require additional information.
+ * For example, autocomplete values tend to be complex objects, with some primaryTextField
+ * that defines which property of the value is shown to the user. To properly display in
+ * readonly format, it is also necessary to pass in that primaryTextField property. Hence,
+ * if the formly type to display in readonly format is autocomplete, then we expect the
+ * autocompleteOptions' primaryTextField property to be defined
+ * 
+ * If the additional information is not passed in, then the value is still displayed to the user,
+ * either as json string if the value is some object, or just as it is otherwise.
+ */
+export interface ReadonlyOptions {
+  // List of options provided to users to choose from
+  providedOptions?: {key: string, value: string} | {label: string, value: string}[],
+
+  // Autocomplete setting used to define primary text field
+  autocompleteOptions?: {
+    primaryTextField: string
+  },
+
+  daterangepickerOptions?: {
+    fromDateKey: string,
+    toDateKey: string,
+  }
+};

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-options.model.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-options.model.ts
@@ -19,6 +19,8 @@ export interface ReadonlyOptions {
     primaryTextField: string
   },
 
+  // Key value that maps to start / end dates of the date range model. 
+  // By default, these values are set to 'fromDate' and 'toDate'
   daterangepickerOptions?: {
     fromDateKey: string,
     toDateKey: string,

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly.module.ts
@@ -10,6 +10,7 @@ import { ReadonlyCheckboxComponent } from './readonly-types/readonly-checkbox';
 import { ReadonlyMulticheckboxComponent } from './readonly-types/readonly-multicheckbox';
 import { ReadonlyDaterangeComponent } from './readonly-types/readonly-daterange';
 import { ReadonlyFileinfoComponent } from './readonly-types/readonly-fileinfo';
+import { ReadonlyContainerComponent } from './readonly-container.component';
 
 @NgModule({
   imports: [
@@ -26,6 +27,7 @@ import { ReadonlyFileinfoComponent } from './readonly-types/readonly-fileinfo';
     ReadonlyMulticheckboxComponent,
     ReadonlyDaterangeComponent,
     ReadonlyFileinfoComponent,
+    ReadonlyContainerComponent,
   ],
   exports: [
     ReadonlyInputComponent,
@@ -37,6 +39,7 @@ import { ReadonlyFileinfoComponent } from './readonly-types/readonly-fileinfo';
     ReadonlyMulticheckboxComponent,
     ReadonlyDaterangeComponent,
     ReadonlyFileinfoComponent,
+    ReadonlyContainerComponent,
   ]
 
 })

--- a/libs/packages/sam-formly/src/lib/formly/sds-formly-options.ts
+++ b/libs/packages/sam-formly/src/lib/formly/sds-formly-options.ts
@@ -1,3 +1,3 @@
-export let sdsFieldWrapper = ['label', 'description', 'validation'];
+export let sdsFieldWrapper = ['readonly', 'label', 'description', 'validation'];
 export let sdsGroupWrapper = ['group']
 export let sdsWrappers = [...sdsGroupWrapper, ...sdsFieldWrapper];

--- a/libs/packages/sam-formly/src/lib/formly/services/formly-utils.service.ts
+++ b/libs/packages/sam-formly/src/lib/formly/services/formly-utils.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@angular/core";
+import { FormlyFieldConfig } from "@ngx-formly/core";
+
+@Injectable()
+export class FormlyUtilsService {
+
+  public static setReadonlyMode(readonlyMode: boolean, fields: FormlyFieldConfig[]) {
+    fields.forEach(field => {
+      this._setReadonlyMode(readonlyMode, field);
+    });
+  }
+
+
+  private static _setReadonlyMode(readonlyMode: boolean, field: FormlyFieldConfig) {
+
+    if (field.fieldGroup) {
+      field.fieldGroup.forEach(field => {
+        this._setReadonlyMode(readonlyMode, field);
+      })
+    }
+
+    if (field.templateOptions) {
+      field.templateOptions.readonlyMode = readonlyMode
+    }
+  }
+} 

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -11,46 +11,51 @@ import * as qs from 'qs';
  */
 @Component({
   template: `
-    <ng-container [ngSwitch]="to.group">
-      <ng-container *ngSwitchCase="'accordion'">
-        <sds-accordion multi="true" displayMode="basic">
-          <sds-accordion-item
-            class="sds-accordion__panel"
-            [expanded]="modelHasValue()"
-          >
-            <sds-accordion-item-header>
-              <span
-                *ngIf="!to.hideLabel"
-                [attr.aria-hidden]="!to.announceLabel ? undefined : 'true'"
-              >
-                {{ to.label }}
-              </span>
-            </sds-accordion-item-header>
-            <ng-container #fieldComponent></ng-container>
-          </sds-accordion-item>
-        </sds-accordion>
-      </ng-container>
-      <ng-container *ngSwitchCase="'panel'">
-        <div
-          class="sds-panel"
-          [ngClass]="{ 'sds-panel--multiple': field?.fieldGroup?.length }"
-        >
+    <ng-container *ngIf="!to.readonlyMode; else defaultTemplate">
+      <ng-container [ngSwitch]="to.group">
+        <ng-container *ngSwitchCase="'accordion'">
+          <sds-accordion multi="true" displayMode="basic">
+            <sds-accordion-item
+              class="sds-accordion__panel"
+              [expanded]="modelHasValue()"
+            >
+              <sds-accordion-item-header>
+                <span
+                  *ngIf="!to.hideLabel"
+                  [attr.aria-hidden]="!to.announceLabel ? undefined : 'true'"
+                >
+                  {{ to.label }}
+                </span>
+              </sds-accordion-item-header>
+              <ng-container #fieldComponent></ng-container>
+            </sds-accordion-item>
+          </sds-accordion>
+        </ng-container>
+        <ng-container *ngSwitchCase="'panel'">
           <div
-            class="sds-panel__header"
-            *ngIf="!to.hideLabel"
-            [attr.aria-hidden]="!to.announceLabel ? undefined : 'true'"
+            class="sds-panel"
+            [ngClass]="{ 'sds-panel--multiple': field?.fieldGroup?.length }"
           >
-            {{ to.label }}
+            <div
+              class="sds-panel__header"
+              *ngIf="!to.hideLabel"
+              [attr.aria-hidden]="!to.announceLabel ? undefined : 'true'"
+            >
+              {{ to.label }}
+            </div>
+            <div class="sds-panel__body">
+              <ng-container #fieldComponent></ng-container>
+            </div>
           </div>
-          <div class="sds-panel__body">
-            <ng-container #fieldComponent></ng-container>
-          </div>
-        </div>
-      </ng-container>
-      <ng-container *ngSwitchDefault>
-        <ng-container #fieldComponent></ng-container>
+        </ng-container>
+        <ng-container *ngSwitchDefault>
+          <ng-container #fieldComponent></ng-container>
+        </ng-container>
       </ng-container>
     </ng-container>
+    <ng-template #defaultTemplate>
+      <ng-container #fieldComponent></ng-container>
+    </ng-template>
   `
 })
 export class FormlyGroupWrapperComponent extends FieldWrapper {

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/readonly.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/readonly.wrapper.ts
@@ -1,0 +1,24 @@
+import { Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { FieldWrapper } from '@ngx-formly/core';
+import { SdsFormlyTypes } from '../models/formly-types';
+/**
+ * @param {string} [to.required] Makes the field required
+ */
+@Component({
+  template: `
+    <div *ngIf="field.type === sdsFormlyTypes.READONLY || to.readonlyMode; else passThrough" [ngClass]="to.readonlyClass">
+      <span *ngIf="to.readonlyTemplate; else defaultTemplate" [innerHTML]="to.readonlyTemplate(field)"></span>
+      <ng-template #defaultTemplate>
+        <sds-readonly-container [formlyFieldConfig]="field"></sds-readonly-container>
+      </ng-template>
+    </div>
+    <ng-template #passThrough>
+      <ng-container #fieldComponent></ng-container>
+    </ng-template>
+  `,
+})
+export class FormlyReadonlyWrapperComponent extends FieldWrapper {
+  @ViewChild('fieldComponent', {read: ViewContainerRef}) fieldComponent: ViewContainerRef;
+
+  sdsFormlyTypes = SdsFormlyTypes;
+}

--- a/libs/packages/sam-formly/src/lib/public-api.ts
+++ b/libs/packages/sam-formly/src/lib/public-api.ts
@@ -10,3 +10,5 @@ export * from './formly-filters/advanced-filters/sds-advanced-filters.service';
 export * from './formly/sds-formly-options';
 export * from './formly/formly.config';
 export * from './formly/sds-formly';
+export * from './formly/models/formly-types';
+export * from './formly/services/formly-utils.service';


### PR DESCRIPTION
## Description
This PR is continuation from #460 - Adds the wrapper level component to consolidate each individual readonly types. The wrapper decides which readonly component to display based on the provided formly type. Also, updated to add enumeration for all formly types we support.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

