### PR TITLE
Add output event on table expansion for Sds-table

### DIFF
--- a/libs/documentation/src/lib/components/table/demos/full/full.component.html
+++ b/libs/documentation/src/lib/components/table/demos/full/full.component.html
@@ -1,4 +1,5 @@
-<sds-table [data]="data" expansion pagination sort [sortFn]="customSort" class="maxh-tablet overflow-auto">
+<sds-table [data]="data" expansion pagination sort [sortFn]="customSort" (expansionClicked)="onExpansionClicked($event)"
+  class="maxh-tablet overflow-auto">
 
   <sds-table-column sdsColumnName="id" sticky="true">
     <ng-template #sdsHeaderCell>ID</ng-template>
@@ -17,7 +18,8 @@
   </sds-table-column>
   <sds-table-column sdsColumnName="email">
     <ng-template #sdsHeaderCell>Email</ng-template>
-    <ng-template #sdsCell let-element="element"><a href="https://beta.sam.gov" (click)="$event.stopPropagation()" class="usa-link">{{ element.email }}</a></ng-template>
+    <ng-template #sdsCell let-element="element"><a href="https://beta.sam.gov" (click)="$event.stopPropagation()"
+        class="usa-link">{{ element.email }}</a></ng-template>
 
   </sds-table-column>
   <sds-table-column sdsColumnName="requests">
@@ -44,7 +46,8 @@
   </sds-table-column>
   <sds-table-column sdsColumnName="actions" stickyEnd="true">
     <ng-template #sdsHeaderCell>Actions</ng-template>
-    <ng-template #sdsCell let-element="element"><a href="#" (click)="edit(element); $event.stopPropagation(); false;" class="usa-link">Edit</a></ng-template>
+    <ng-template #sdsCell let-element="element"><a href="#" (click)="edit(element); $event.stopPropagation(); false;"
+        class="usa-link">Edit</a></ng-template>
 
   </sds-table-column>
 

--- a/libs/documentation/src/lib/components/table/demos/full/full.component.ts
+++ b/libs/documentation/src/lib/components/table/demos/full/full.component.ts
@@ -51,4 +51,8 @@ export class TableFullComponent {
     }
   };
 
+  onExpansionClicked(element:any) {
+    console.log('Expansion Clicked', element);
+  }
+
 }

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
@@ -62,7 +62,7 @@ export class ReadonlyContainerComponent implements OnInit {
     }
 
     // We do array access from field config for daterangepicker, which can be undefined for other types, 
-    // hence this is sectioned off in a conditional 
+    // hence this is sectioned off in a conditional
     if (this.formlyFieldConfig.type === this.sdsFormlyTypes.DATERANGEPICKER) {
       this.additionalConfig.daterangepickerOptions = {
         fromDateKey: this.formlyFieldConfig.fieldGroup[0].key as any,

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.ts
@@ -62,7 +62,7 @@ export class ReadonlyContainerComponent implements OnInit {
     }
 
     // We do array access from field config for daterangepicker, which can be undefined for other types, 
-    // hence this is sectioned off in a conditional
+    // hence this is sectioned off in a conditional 
     if (this.formlyFieldConfig.type === this.sdsFormlyTypes.DATERANGEPICKER) {
       this.additionalConfig.daterangepickerOptions = {
         fromDateKey: this.formlyFieldConfig.fieldGroup[0].key as any,

--- a/libs/packages/sam-material-extensions/src/lib/table/table.component.html
+++ b/libs/packages/sam-material-extensions/src/lib/table/table.component.html
@@ -42,7 +42,7 @@
       <td mat-header-cell *matHeaderCellDef></td>
       <td mat-cell *matCellDef="let element"
         class="cursor-pointer"
-        (click)="!rowConfig.expandOnClick ? (expandedElement = expandedElement === element ? null : element) : false"
+        (click)="onExpansionClicked(element)"
       >
         <fa-icon *ngIf="element == expandedElement" [icon]="['fas', 'chevron-up']" size="sm"></fa-icon>
         <fa-icon *ngIf="element != expandedElement" [icon]="['fas', 'chevron-down']" size="sm"></fa-icon>

--- a/libs/packages/sam-material-extensions/src/lib/table/table.component.ts
+++ b/libs/packages/sam-material-extensions/src/lib/table/table.component.ts
@@ -11,7 +11,9 @@ import {
   Directive,
   SimpleChanges,
   OnChanges,
-  ChangeDetectorRef
+  ChangeDetectorRef,
+  Output,
+  EventEmitter
 } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import {MatTableDataSource, MatTable} from '@angular/material/table';
@@ -185,6 +187,9 @@ export class SdsTableComponent implements OnInit, AfterContentInit, AfterViewIni
   }
   private _expansion = false;
 
+  @Output()
+  expansionClicked = new EventEmitter<any>();
+
   dataSource: MatTableDataSource<any>;
   expandedElement: any;
 
@@ -309,5 +314,10 @@ export class SdsTableComponent implements OnInit, AfterContentInit, AfterViewIni
 
     return data[sortHeaderId];
   };
+
+  onExpansionClicked(element: any) {
+    !this.rowConfig.expandOnClick ? (this.expandedElement = this.expandedElement === element ? null : element) : false;
+    this.expansionClicked.emit(this.expandedElement);
+  }
 
 }


### PR DESCRIPTION
## Description
Allow users the ability to listen for and react to table expansion/collapse event.

## Motivation and Context
This event gives users the option to dynamically load data on table item expansion rather than needing to eagerly load all the information.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

