### PR TITLE
Add recursive definition for fieldgroups in hide check for sds-filters

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -124,8 +124,6 @@ export class SdsFiltersComponent implements OnInit {
         });
         this.cdr.detectChanges();
       }
-    } else if (this.model) {
-      this.checkForHide();
     }
   }
   /**

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -124,6 +124,8 @@ export class SdsFiltersComponent implements OnInit {
         });
         this.cdr.detectChanges();
       }
+    } else if (this.model) {
+      this.checkForHide();
     }
   }
   /**
@@ -139,17 +141,13 @@ export class SdsFiltersComponent implements OnInit {
       const [lastKey] = key.split('.').slice(-1);
       this.fields.forEach(field => {
         if (key.includes(field.key)) {
-          let hiddenField;
           if (field.fieldGroup) {
             const fieldExists = this.findFieldInFieldGroup(field.fieldGroup, lastKey);
             if (fieldExists) {
               field.hide = false;
             }
           } else {
-            hiddenField = field;
-          }
-          if (hiddenField.hide) {
-            hiddenField.hide = false;
+            field.hide = false;
           }
         }
       });

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -124,6 +124,8 @@ export class SdsFiltersComponent implements OnInit {
         });
         this.cdr.detectChanges();
       }
+    } else if (this.model) {
+      this.checkForHide();
     }
   }
   /**
@@ -141,7 +143,10 @@ export class SdsFiltersComponent implements OnInit {
         if (key.includes(field.key)) {
           let hiddenField;
           if (field.fieldGroup) {
-            hiddenField = field.fieldGroup.find(item => item.key === lastKey);
+            const fieldExists = this.findFieldInFieldGroup(field.fieldGroup, lastKey);
+            if (fieldExists) {
+              field.hide = false;
+            }
           } else {
             hiddenField = field;
           }
@@ -151,6 +156,31 @@ export class SdsFiltersComponent implements OnInit {
         }
       });
     });
+  }
+
+  /**
+   * Recursively iterate over each field as well as potential field groups of the field
+   * to find a field with the given key. Returns true if field exists. Also toggles
+   * hide value of formly field for the key as well as it's parent fields to false.
+   * @param fields - The list of formly fields to search for the given key
+   * @param key - The key of the formly field config to search for
+   */
+  private findFieldInFieldGroup(fields: FormlyFieldConfig[], key: any) {
+    let existsInFieldGroup = false;
+    fields.forEach(field => {
+      if (field.fieldGroup) {
+        existsInFieldGroup = existsInFieldGroup || this.findFieldInFieldGroup(field.fieldGroup, key);
+        if (existsInFieldGroup) {
+          field.hide = false;
+        }
+      }
+      else if (field.key === key) {
+        existsInFieldGroup = true;
+        field.hide = false;
+      }
+    });
+
+    return existsInFieldGroup;
   }
 
   onModelChange(change: any) {


### PR DESCRIPTION
## Description
Currently the sds filters only checks 1 level deep for value in filters when checking to determine whether those filters should be automatically visible or not. So for field configs with nested field groups, the filters were not automatically becoming visible despite having value. This change modifies the logic to add a recursive check through field groups when checking for filter model's value.

## Motivation and Context
From github issue #477 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

