### PR TITLE
Update icon styling to ensure bootstrap icon size based on em not px

### DIFF
--- a/libs/packages/components/src/lib/icon/icon.component.scss
+++ b/libs/packages/components/src/lib/icon/icon.component.scss
@@ -8,6 +8,13 @@ $rotation-values: 90 180 270;
   }
 }
 
+i-bs ::ng-deep{
+  svg {
+    width: 1em;
+    height: 1em;
+  }
+}
+
 i-bs.size-xs{
   font-size: .75em;
 }


### PR DESCRIPTION
## Description
The package that is being used to provide bootstrap icons updated to use the latest bootstrap icons. As a result, the existing icons were updated to have their width and height updated to be 16px rather than 1em as it was when these icons were initially pulled into SDS. Added styling to override this and ensure icons continue to have their height and width set at 1em so their size will scale properly.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-45480

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

