### PR TITLE
Update header demo to use word notifications

### DIFF
--- a/libs/documentation/src/lib/components/header/demos/basic/header-basic.component.ts
+++ b/libs/documentation/src/lib/components/header/demos/basic/header-basic.component.ts
@@ -29,7 +29,7 @@ export class HeaderBasic implements OnInit {
       {
         imageClassPrefix: 'sds',
         imageClass: 'messages',
-        text: 'Messages',
+        text: 'Notifications',
         route: '/',
         id: 'messages',
         mode: NavigationMode.INTERNAL

--- a/libs/documentation/src/lib/components/header/demos/header-alerts/header-alerts.component.ts
+++ b/libs/documentation/src/lib/components/header/demos/header-alerts/header-alerts.component.ts
@@ -28,7 +28,7 @@ export class HeaderAlertsComponent implements OnInit {
       {
         imageClassPrefix: 'sds',
         imageClass: 'messages',
-        text: 'Messages',
+        text: 'Notifications',
         route: '/',
         id: 'messages',
         mode: NavigationMode.INTERNAL

--- a/libs/documentation/src/lib/components/header/demos/header-hidden-logo/header-hidden-logo.component.ts
+++ b/libs/documentation/src/lib/components/header/demos/header-hidden-logo/header-hidden-logo.component.ts
@@ -29,7 +29,7 @@ export class HeaderHiddenLogoComponent implements OnInit {
       {
         imageClassPrefix: 'sds',
         imageClass: 'messages',
-        text: 'Messages',
+        text: 'Notifications',
         route: '/',
         id: 'messages',
         mode: NavigationMode.INTERNAL


### PR DESCRIPTION
## Description
Update our term usage in header demo: Messages changed to Notifications


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

