### PR TITLE
Add documentation section for stacking icons

### DIFF
--- a/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.html
+++ b/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.html
@@ -1,0 +1,31 @@
+<p>To stack two icons, apply the <code>sds-stack</code> class the parent HTML
+  element of the icons you want to stack. Then add the
+  <code>sds-stack-icon</code> class to the icons you want stacked.</p>
+<p>Classes starting with <code>sds-</code> and followed by a sds-icon size
+  multiplier ie: <code>sds-sm</code> or <code>sds-2x</code> can be applied
+  to the parent HTML element to scale the overall size of the stacked icons.
+  For further refinement of one of the icons, the <code>size</code> input of
+  sds-icon can be used.</p>
+<div style="display: flex; align-items: flex-end">
+  <div style="padding-right: 1em; text-align: center;">
+    <div class="sds-stack sds-1x">
+      <sds-icon class="sds-stack-icon" [size]="'2x'" [icon]="['bs', 'circle-fill']"></sds-icon>
+      <sds-icon class="sds-stack-icon text-base-lightest" [size]="'lg'" [icon]="['bs', 'caret-left']"></sds-icon>
+    </div>
+    <p>sds-1x</p>
+  </div>
+  <div style="padding-right: 1em; text-align: center;">
+    <div class="sds-stack sds-2x">
+      <sds-icon class="sds-stack-icon" [size]="'2x'" [icon]="['bs', 'circle-fill']"></sds-icon>
+      <sds-icon class="sds-stack-icon text-base-lightest" [size]="'lg'" [icon]="['bs', 'caret-left']"></sds-icon>
+    </div>
+    <p>sds-2x</p>
+  </div>
+  <div style="padding-right: 1em; text-align: center;">
+    <div class="sds-stack sds-4x">
+      <sds-icon class="sds-stack-icon" [size]="'2x'" [icon]="['bs', 'circle-fill']"></sds-icon>
+      <sds-icon class="sds-stack-icon text-base-lightest" [size]="'lg'" [icon]="['bs', 'caret-left']"></sds-icon>
+    </div>
+    <p>sds-4x</p>
+  </div>
+</div>

--- a/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.ts
+++ b/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  templateUrl: './icons-stacking.component.html',
+  styleUrls: ['./icons-stacking.component.scss']
+})
+export class IconsStackingComponent {
+
+}

--- a/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.ts
+++ b/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  templateUrl: './icons-stacking.component.html',
-  styleUrls: ['./icons-stacking.component.scss']
+  templateUrl: './icons-stacking.component.html'
 })
 export class IconsStackingComponent {
 

--- a/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.module.ts
+++ b/libs/documentation/src/lib/components/icons/demos/stacking/icons-stacking.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SdsIconModule } from '@gsa-sam/components';
+import { IconsStackingComponent } from './icons-stacking.component'
+
+
+@NgModule({
+  imports: [CommonModule, SdsIconModule],
+  declarations: [IconsStackingComponent],
+  exports: [IconsStackingComponent],
+  bootstrap: [IconsStackingComponent]
+})
+export class IconsStackingModule {}

--- a/libs/documentation/src/lib/components/icons/icons.module.ts
+++ b/libs/documentation/src/lib/components/icons/icons.module.ts
@@ -19,9 +19,18 @@ import { IconsScaling } from './demos/scaling/icons-scaling.component';
 import { DocumentationAPIPage } from '../shared/api-page/docs-api.component';
 import { DocumentationSourcePage } from '../shared/source-page/source.component';
 import { DocumentationTemplatePage } from '../shared/template-page/template.component';
+import { IconsStackingComponent } from './demos/stacking/icons-stacking.component';
+import { IconsStackingModule } from './demos/stacking/icons-stacking.module';
 
 declare var require: any;
 const DEMOS = {
+  stacking: {
+    title: 'Stacking Icons',
+    type: IconsStackingComponent,
+    code: require('!!raw-loader!./demos/stacking/icons-stacking.component'),
+    markup: require('!!raw-loader!./demos/stacking/icons-stacking.component.html'),
+    path: 'libs/documentation/src/lib/components/icons/demos/stacking'
+  },
   coloring: {
     title: 'Coloring Icons',
     type: IconsColoring,
@@ -90,7 +99,8 @@ export const ROUTES = [
     IconsBootstrapModule,
     IconsColoringModule,
     IconsScalingModule,
-    IconsRotationModule
+    IconsRotationModule,
+    IconsStackingModule
   ]
 })
 export class IconsModule {

--- a/libs/packages/components/src/lib/icon/icon.component.scss
+++ b/libs/packages/components/src/lib/icon/icon.component.scss
@@ -12,6 +12,7 @@ i-bs ::ng-deep{
   svg {
     width: 1em;
     height: 1em;
+    margin-bottom: -0.1em;
   }
 }
 


### PR DESCRIPTION
## Description
Added documentation outlining how to stack SDS icons.
Added one css tweak to address space added to bottom of SVG due to display:inline-block being applied to element. Without this there is ~0.1 em added to the bottom which messes with alignment.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-45484

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

