### PR TITLE
Resolve issue with autocomplete disable, unsubscribe on layout during onDestroy

### DIFF
--- a/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
@@ -134,6 +134,10 @@ export class SDSAutocompleteComponent implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
+    if (this.autocompleteSearch) {
+      this.autocompleteSearch.setDisabledState(isDisabled);
+      this.cd.detectChanges();
+    }
   }
 
   isSingleMode(): boolean {

--- a/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
@@ -134,10 +134,7 @@ export class SDSAutocompleteComponent implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
-    if (this.autocompleteSearch) {
-      this.autocompleteSearch.setDisabledState(isDisabled);
-      this.cd.detectChanges();
-    }
+    this.cd.detectChanges();
   }
 
   isSingleMode(): boolean {

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Input, ContentChild, TemplateRef, Optional } from '@angular/core';
-import { BehaviorSubject } from "rxjs";
+import { Component, OnInit, Input, ContentChild, TemplateRef, Optional, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Subscription } from "rxjs";
 import { SearchListInterface, SearchListConfiguration } from './model/search-list-layout.model';
 import { SDSFormlyUpdateComunicationService } from '@gsa-sam/sam-formly';
 
@@ -8,7 +8,7 @@ import { SDSFormlyUpdateComunicationService } from '@gsa-sam/sam-formly';
   templateUrl: './search-list-layout.component.html',
   styleUrls: ['./search-list-layout.component.scss']
 })
-export class SearchListLayoutComponent implements OnInit {
+export class SearchListLayoutComponent implements OnInit, OnDestroy {
 
   /**
   * Child Template to be used to display the data for each item in the list of items
@@ -39,6 +39,8 @@ export class SearchListLayoutComponent implements OnInit {
    */
   private filterData: any;
 
+  private formlySubscription: Subscription;
+
   ngOnInit() {
     this.page.pageSize = this.configuration.pageSize;
     this.sortField = this.configuration.defaultSortValue;
@@ -48,11 +50,17 @@ export class SearchListLayoutComponent implements OnInit {
       }
     );
     if (this.formlyUpdateComunicationService) {
-      this.formlyUpdateComunicationService.filterUpdate.subscribe(
+      this.formlySubscription = this.formlyUpdateComunicationService.filterUpdate.subscribe(
         (filter) => {
           this.updateFilter(filter);
         }
       )
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.formlySubscription) {
+      this.formlySubscription.unsubscribe();
     }
   }
 


### PR DESCRIPTION
## Description
Contains two fixes:
1. Unsubscribe from formly update communication service - Issue brought up through Search mfe - continuously navigating between search and saved search page was causing the number of api calls made to retrieve search results to increase.

2. Manually set disable state of internal autocomplete component - Another issue brought up through Search mfe, and mentioned by Kidany where using expression properties to toggle disabled state of autocomplete was not disabling the autocomplete input until another user event was given (ie click anywhere on page).

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

