### PR TITLE
Add optional parameter to merge queryparam in sidenav

### DIFF
--- a/libs/packages/components/src/lib/side-navigation/model/side-navigation-model.ts
+++ b/libs/packages/components/src/lib/side-navigation/model/side-navigation-model.ts
@@ -1,3 +1,4 @@
+import { QueryParamsHandling } from '@angular/router';
 import { INavigationLink, NavigationMode, Selectable } from '../../common-navigation/common-navigation-model';
 
 export class SideNavigationModel {
@@ -50,6 +51,7 @@ export class NavigationLink implements Selectable, INavigationLink {
         [k: string]: any;
     }
 
+    queryParamsHandling?: QueryParamsHandling;
 }
 
 

--- a/libs/packages/components/src/lib/side-navigation/side-navigation.component.html
+++ b/libs/packages/components/src/lib/side-navigation/side-navigation.component.html
@@ -20,7 +20,10 @@
 
 <ng-template #sideNavRouteLinkTemplate let-link>
   <a [attr.class]="link.selected ? ' usa-current' : ''" [routerLink]="[link.route]" (click)="linkClickEvent(link)"
-    [queryParams]="link.queryParams"><span>{{link.text}}</span></a>
+    [queryParams]="link.queryParams" 
+    [queryParamsHandling]="link.queryParamsHandling ? link.queryParamsHandling : 'merge'">
+      <span>{{link.text}}</span>
+  </a>
 </ng-template>
 
 <ng-template #sideNavHREFLinkTemplate let-link>

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -160,13 +160,14 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
 
   /**
    * updates the filter and set the page number to 1 and calls imported service
-   * @param filter
+   * @param filter - the updated filter model
+   * @param updateNavigation - Whether to perform a route navigation or not - defaults to true if not specified
    */
-  public updateFilter(filter: any) {
+  public updateFilter(filter: any, updateNavigation = true) {
     this.filterData = filter;
     this.page.pageNumber = this.page.default ? this.page.pageNumber : 1;
     this.page.default = filter ? false : true;
-    this.updateContent();
+    this.updateContent(updateNavigation);
   }
 
   updateNavigation() {
@@ -259,8 +260,8 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
   /**
    * calls service when updated
    */
-  private updateContent() {
-    if (this.isHistoryEnabled) {
+  private updateContent(updateNavigation = true) {
+    if (this.isHistoryEnabled && updateNavigation) {
       this.updateNavigation();
     }
 

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -161,13 +161,12 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
   /**
    * updates the filter and set the page number to 1 and calls imported service
    * @param filter - the updated filter model
-   * @param updateNavigation - Whether to perform a route navigation or not - defaults to true if not specified
    */
-  public updateFilter(filter: any, updateNavigation = true) {
+  public updateFilter(filter: any) {
     this.filterData = filter;
     this.page.pageNumber = this.page.default ? this.page.pageNumber : 1;
     this.page.default = filter ? false : true;
-    this.updateContent(updateNavigation);
+    this.updateContent();
   }
 
   updateNavigation() {
@@ -260,8 +259,8 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
   /**
    * calls service when updated
    */
-  private updateContent(updateNavigation = true) {
-    if (this.isHistoryEnabled && updateNavigation) {
+  private updateContent() {
+    if (this.isHistoryEnabled) {
       this.updateNavigation();
     }
 
@@ -296,6 +295,5 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
         this.filterUpdateModelService.updateModel({});
       }
     }
-    this.updateContent();
   }
 }


### PR DESCRIPTION
## Description
Stems from https://cm-jira.usa.gov/browse/IAEDEV-46387 - Users are currently using updateFilter method in resultList to manually update their filter model. However, they are also forced to perform route navigation when they do. This change adds an optional parameter to updateFilter method to disable route navigation when updating filters.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-46387
#500 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

