### PR TITLE
Remove onpush change detection strategy

### DIFF
--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.ts
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.ts
@@ -66,7 +66,6 @@ export class SdsAccordionItemComponent {
   selector: 'sds-accordion-next',
   templateUrl: './accordion.component.html',
   styleUrls: ['./accordion.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SdsAccordionComponent {
   @ViewChild(MatAccordion) accordion: MatAccordion;


### PR DESCRIPTION
## Description
The accordions in our demo were not expanding/closing when the buttons 'Open First Item' / 'Close First Item' was clicked. Seems to be due to the OnPush change detection strategy preventing change detection when the expanded value changed

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-46469

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

