### PR TITLE
update pagination demo and add flex display for datepicker with toggle

### DIFF
--- a/libs/documentation/src/lib/components/table/demos/full/full.component.html
+++ b/libs/documentation/src/lib/components/table/demos/full/full.component.html
@@ -1,4 +1,4 @@
-<sds-table [data]="data" expansion pagination sort [sortFn]="customSort" (expansionClicked)="onExpansionClicked($event)"
+<sds-table [data]="data" [pagination]="true" expansion sort [sortFn]="customSort" (expansionClicked)="onExpansionClicked($event)"
   class="maxh-tablet overflow-auto">
 
   <sds-table-column sdsColumnName="id" sticky="true">

--- a/libs/documentation/src/lib/components/table/demos/pagination/pagination.component.html
+++ b/libs/documentation/src/lib/components/table/demos/pagination/pagination.component.html
@@ -1,4 +1,4 @@
-<sds-table [data]="data" pagination>
+<sds-table [data]="data" [pagination]="true">
 
   <sds-table-column sdsColumnName="id">
     <ng-template #sdsHeaderCell>ID</ng-template>

--- a/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
@@ -4,6 +4,7 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-datepicker',
   template: `
+    <div class="display-flex">
     <input
       [id]="id"
       class="usa-input display-inline-block margin-top-3"
@@ -16,8 +17,9 @@ import { FieldType } from '@ngx-formly/core';
       [matDatepicker]="picker"
       placeholder="Choose a date"
     />
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker-toggle class="padding-top-1" matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker [startAt]="to.startDate" #picker></mat-datepicker>
+</div>
   `
 })
 export class FormlyFieldDatePickerComponent extends FieldType {}

--- a/libs/packages/sam-formly/src/lib/formly/types/daterangepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/daterangepicker.ts
@@ -4,25 +4,27 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-daterangepicker',
   template: `
-    <mat-date-range-input [formGroup]="formControl" [rangePicker]="picker" [min]="to.minDate" [max]="to.maxDate" [id]="id"
-      class="usa-input display-inline-block margin-top-3"
-      [formlyAttributes]="field"
-      [class.usa-input--error]="showError">
-      <input matStartDate
-        [attr.aria-label]="field.fieldGroup[0]?.templateOptions?.placeholder || 'Start Date'"
-        [formlyAttributes]="field.fieldGroup[0]"
-        [placeholder]="field.fieldGroup[0]?.templateOptions?.placeholder || 'Start Date'"
-        [formControlName]="field.fieldGroup[0].key"
-        />
-        <input matEndDate
-        [attr.aria-label]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
-        [formlyAttributes]="field.fieldGroup[1]"
-        [placeholder]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
-        [formControlName]="field.fieldGroup[1].key"
-      />  
-    </mat-date-range-input>
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-date-range-picker [startAt]="to.startDate" #picker></mat-date-range-picker>
+    <div class="display-flex">
+      <mat-date-range-input [formGroup]="formControl" [rangePicker]="picker" [min]="to.minDate" [max]="to.maxDate" [id]="id"
+        class="usa-input display-inline-block margin-top-3"
+        [formlyAttributes]="field"
+        [class.usa-input--error]="showError">
+        <input matStartDate
+          [attr.aria-label]="field.fieldGroup[0]?.templateOptions?.placeholder || 'Start Date'"
+          [formlyAttributes]="field.fieldGroup[0]"
+          [placeholder]="field.fieldGroup[0]?.templateOptions?.placeholder || 'Start Date'"
+          [formControlName]="field.fieldGroup[0].key"
+          />
+          <input matEndDate
+          [attr.aria-label]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
+          [formlyAttributes]="field.fieldGroup[1]"
+          [placeholder]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
+          [formControlName]="field.fieldGroup[1].key"
+        />  
+      </mat-date-range-input>
+      <mat-datepicker-toggle class="padding-top-3" matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-date-range-picker [startAt]="to.startDate" #picker></mat-date-range-picker>
+    </div>
   `,
   styles: ['.mat-date-range-input-start-wrapper {overflow: unset !important; }', 
             '.mat-date-range-input-end-wrapper {flex-grow: unset !important; }',


### PR DESCRIPTION
Resolves issue with pagination demo where the list was not paginated. Updates styling of datepicker so that the calendar button does not wrap into a separate line

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

