### PR TITLE
Update write valuelogic of autocomplete to accept duplicate updates

### DIFF
--- a/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/packages/components/src/lib/autocomplete/autocomplete.component.ts
@@ -88,11 +88,11 @@ export class SDSAutocompleteComponent implements ControlValueAccessor {
   // If there is a value we will just overwrite items
   // If there is no value we reset the items array to be empty
   writeValue(value: any) {
-    if (value instanceof SDSSelectedItemModel && value.items && value.items.length && this.model.items !== value.items) {
+    if (value instanceof SDSSelectedItemModel && value.items && value.items.length) {
       this.model.items = [...value.items];
       this.cd.markForCheck();
     }
-    else if (value && value.length && this.model.items !== value) {
+    else if (value && value.length) {
       this.model.items = value;
       this.cd.markForCheck();
     } else {


### PR DESCRIPTION
## Description
Update logic of autocomplete to accept consecutive updates - Considering our current logic, if something were to write the same value to autocomplete component twice, the first time it would update normally, but the second time, it would go into the else condition (line 98-99 in autocomplete.ts), and potentially reset the autocomplete model in line 102.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

