### PR TITLE
Update focus issues on popup and fileinfo

### DIFF
--- a/libs/documentation/src/lib/components/popup/demos/basic/popup-basic.component.html
+++ b/libs/documentation/src/lib/components/popup/demos/basic/popup-basic.component.html
@@ -3,19 +3,20 @@
 </div>
 
 <div [sdsPopup]='tooltip' position="top-center" placement="out"
-  aria-label="Tooltip that hides when scrolled out of the container">
+  aria-label="Tooltip that hides when scrolled out of the container"
+  tabindex="0">
   <div class="tooltip tooltip-left">
     <div>popup outside</div>
   </div>
 </div>
 <br><br>
 <div #tooltipbutton>
-  <button class="usa-button usa-button--base">
+  <button class="usa-button usa-button--base" tabindex="-1">
     tooltip
   </button>
 </div>
 
-<div [sdsPopup]='tooltipbutton' position="bottom-center" placement="out"
+<div [sdsPopup]='tooltipbutton' position="bottom-center" placement="out" tabindex="0"
   aria-label="Tooltip that hides when scrolled out of the container">
   <div class="tooltip tooltip-left">
     <div>popup outside</div>
@@ -29,7 +30,7 @@
 </div>
 
 <div [sdsPopup]='tooltipRichcontent' position="top-center" placement="out"
-  aria-label="Tooltip that hides when scrolled out of the container">
+  aria-label="Tooltip that hides when scrolled out of the container" tabindex="0">
   <div class="sds-alert bg-base-lightest ">
     <div class="sds-alert-icon">
       <i class="fa fa-exclamation"></i>
@@ -50,7 +51,7 @@
         </span>
       </div>
       <div [sdsPopup]='tooltipForIn' position="top-left" placement="in"
-        aria-label="Tooltip that hides when scrolled out of the container">
+        aria-label="Tooltip that hides when scrolled out of the container" tabindex="0">
         <div class="radius-lg shadow-2 margin-y-neg-1x05 width-card-lg bg-white padding-left-1 padding-bottom-1 border">
           <svg class="svg-inline--fa fa-information-circle fa-w-16 fa-2x float-right margin-1" aria-hidden="true"
             focusable="false" data-prefix="sds" data-icon="information-circle" role="img"
@@ -73,7 +74,7 @@
           </span>
         </div>
         <div [sdsPopup]='tooltipForRight' position="top-right" placement="in"
-          aria-label="Tooltip that hides when scrolled out of the container">
+          aria-label="Tooltip that hides when scrolled out of the container" tabindex="0">
           <div
             class="radius-lg shadow-2 margin-y-neg-1x05 width-card-lg bg-white padding-left-1 padding-bottom-1 border">
             <svg class="svg-inline--fa fa-information-circle fa-w-16 fa-2x float-right margin-1" aria-hidden="true"
@@ -110,7 +111,7 @@
         </span>
       </div>
       <div [sdsPopup]='tooltipForCenter' position="bottom-center" placement="in"
-        aria-label="Tooltip that hides when scrolled out of the container">
+        aria-label="Tooltip that hides when scrolled out of the container" tabindex="0">
         <div class="radius-lg shadow-2 margin-y-neg-1x05 width-card-lg bg-white padding-left-1 padding-bottom-1 border">
           <svg class="svg-inline--fa fa-information-circle fa-w-16 fa-2x float-right margin-1" aria-hidden="true"
             focusable="false" data-prefix="sds" data-icon="information-circle" role="img"

--- a/libs/packages/sam-formly/src/lib/formly/types/fileinfo.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/fileinfo.ts
@@ -14,8 +14,12 @@ import { FieldType } from '@ngx-formly/core';
         <div
           class="sds-card mobile-lg:grid-col"
           [ngClass]="{ 'sds-card-selected': formControl.value == option.value }"
+          tabindex="0"
+          (keyup.enter)="formControl.setValue(option.value)"
+          [attr.aria-label]="option.label + ' ' + option.value"
         >
           <input
+            tabindex="-1"
             type="radio"
             [id]="id + '_' + i"
             class="usa-sr-only usa-radio__input"


### PR DESCRIPTION
Updates popup demo so that the div's that contain the pop-up directive can be focused on and display the tooltips through keyboard.
Updates fileinfo so that each fileinfo item can be focused and properly selected through enter key press

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

