### PR TITLE
Add default value option for layout component

### DIFF
--- a/libs/documentation/src/lib/pages/layout/layout.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout.component.ts
@@ -27,6 +27,7 @@ export class ResultsLayoutComponent implements AfterViewInit, OnInit {
       { text: 'Entity Name', value: 'legalBusinessName' },
       { text: 'Status', value: 'registrationStatus' },
     ],
+    defaultFilterValue: {status: {registrationStatus: {Active: true}}},
   };
 
   /* Sort config change demo */

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/model/search-list-layout.model.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/model/search-list-layout.model.ts
@@ -92,6 +92,11 @@ export class SearchListConfiguration {
      */
     pageSize: number = 25;
 
+    /**
+     * Default values to use during initialization when there is none in url.
+     */
+    defaultFilterValue: any = {};
+
 }
 
 export interface ResultsModel {

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/model/search-list-layout.model.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/model/search-list-layout.model.ts
@@ -95,7 +95,7 @@ export class SearchListConfiguration {
     /**
      * Default values to use during initialization when there is none in url.
      */
-    defaultFilterValue: any = {};
+    defaultFilterValue?: any = {};
 
 }
 

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -153,7 +153,7 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
       if (paramModel && paramModel['sfm']) {
         this.filterUpdateModelService.updateModel(paramModel['sfm']);
       } else {
-        this.filterUpdateModelService.updateModel({});
+        this.filterUpdateModelService.updateModel(this.configuration.defaultFilterValue);
       }
     }
   }


### PR DESCRIPTION
Add option for users to define what default filter values should be if there are no filter values in URL

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

