### PR TITLE
Remove borders in table for material calendar in datepickers

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 
 @Component({
@@ -20,6 +20,10 @@ import { FieldType } from '@ngx-formly/core';
     <mat-datepicker-toggle class="padding-top-1" matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker [startAt]="to.startDate" #picker></mat-datepicker>
 </div>
-  `
+  `,
+  styles: [
+    'table.mat-calendar-table td, table.mat-calendar-table th {border-style: none; background-color: unset; }'
+  ],
+  encapsulation: ViewEncapsulation.None,
 })
 export class FormlyFieldDatePickerComponent extends FieldType {}


### PR DESCRIPTION
Adds CSS styling that overrides USWDS' style for table. This change will remove table/cell borders in the angular material calendar for all our date-pickers

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

