### PR TITLE
Resolve datepicker accordion autoclose and onChange not firing

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/datepicker.ts
@@ -16,6 +16,7 @@ import { FieldType } from '@ngx-formly/core';
       [max]="to.maxDate"
       [matDatepicker]="picker"
       placeholder="Choose a date"
+      (ngModelChange)="to.change ? to.change(field) : ''"
     />
     <mat-datepicker-toggle class="padding-top-1" matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker [startAt]="to.startDate" #picker></mat-datepicker>

--- a/libs/packages/sam-formly/src/lib/formly/types/daterangepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/daterangepicker.ts
@@ -14,12 +14,14 @@ import { FieldType } from '@ngx-formly/core';
           [formlyAttributes]="field.fieldGroup[0]"
           [placeholder]="field.fieldGroup[0]?.templateOptions?.placeholder || 'Start Date'"
           [formControlName]="field.fieldGroup[0].key"
+          (ngModelChange)="field.fieldGroup[0]?.templateOptions?.change ? field.fieldGroup[0].templateOptions.change(field.fieldGroup[0]) : ''"
           />
           <input matEndDate
           [attr.aria-label]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
           [formlyAttributes]="field.fieldGroup[1]"
           [placeholder]="field.fieldGroup[1]?.templateOptions?.placeholder || 'End Date'"
           [formControlName]="field.fieldGroup[1].key"
+          (ngModelChange)="field.fieldGroup[1]?.templateOptions?.change ? field.fieldGroup[1].templateOptions.change(field.fieldGroup[1]) : ''"
         />  
       </mat-date-range-input>
       <mat-datepicker-toggle class="padding-top-3" matSuffix [for]="picker"></mat-datepicker-toggle>

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -72,7 +72,7 @@ export class FormlyGroupWrapperComponent extends FieldWrapper {
         this.formControl.value instanceof Object
           ? qs.stringify(this.formControl.value, { skipNulls: true })
           : this.formControl.value;
-      return hasValue ? true : false;
+      return hasValue || this.formControl.dirty ? true : false;
     }
   }
 }


### PR DESCRIPTION
Resolves issue where accordion wrappers around datepicker would auto-close when the datepicker runs into validation errors.
Resolves issue of datepicker's templateoption's onchange not being called when a date is selected from calendar


## Motivation and Context
#536 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

