### PR TITLE
Resolve jaws issues in autocomplete and selection panel

### DIFF
--- a/libs/documentation/src/lib/components/collapse/demos/basic/collapse-basic.component.html
+++ b/libs/documentation/src/lib/components/collapse/demos/basic/collapse-basic.component.html
@@ -1,16 +1,11 @@
 <div class="text-center">
-  <button type="button"
-  class="usa-button text-center"
-  [attr.aria-expanded]="!isCollapsedContent"
-  aria-controls="collapseID"
-  (click)="isCollapsedContent = !isCollapsedContent"
-  > Show / Hide Content
+  <button type="button" class="usa-button text-center" [attr.aria-expanded]="!isCollapsedContent"
+    aria-controls="collapseID" (click)="isCollapsedContent = !isCollapsedContent"> Show / Hide Content
   </button>
 </div>
 
-<p
-  id="collapseID"
-  [sdsCollapse]="isCollapsedContent"
-   class="bg-base-lighter margin-top-1 padding-2">
-   What is Lorem Ipsum Lorem Ipsum is simply dummy text of the printing.
-</p>
+<span aria-live="polite">
+  <p id="collapseID" [sdsCollapse]="isCollapsedContent" class="bg-base-lighter margin-top-1 padding-2">
+    What is Lorem Ipsum Lorem Ipsum is simply dummy text of the printing.
+  </p>
+</span>

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -174,23 +174,30 @@
           *ngIf="inputValue && !disabled"
           role="button"
           aria-label="Clear input"
-          aria-hidden="false"
           (click)="clearInput()"
           (keyup.enter)="clearInput()"
           tabindex="0"
         >
           <fa-icon [icon]="['fas', 'times']" size="xs"></fa-icon>
         </span>
-            <span *ngIf="!configuration.isTagModeEnabled" role="button" aria-label="Clear input" aria-hidden="false" class="margin-left-1" tabindex="0">
+          <span *ngIf="!configuration.isTagModeEnabled" class="margin-left-1">
           <fa-icon
+            role="button"
+            aria-label="Display Options"
+            tabindex="0"
             *ngIf="!showResults && !disabled"
             (click)="openOptions()"
+            (keyup.enter)="openOptions()"
             [icon]="['fas', 'caret-down']"
             size="sm"
           ></fa-icon>
           <fa-icon
+            role="button"
+            aria-label="Hide Options"
+            tabindex="0"
             *ngIf="showResults && !disabled"
             (click)="checkForFocus($event)"
+            (keyup.enter)="checkForFocus()"
             [icon]="['fas', 'caret-up']"
             size="sm"
           ></fa-icon>

--- a/libs/packages/components/src/lib/selection-panel/selection-panel.component.html
+++ b/libs/packages/components/src/lib/selection-panel/selection-panel.component.html
@@ -5,10 +5,12 @@
     (keyup.enter)="panelExpanded = !panelExpanded"
     >
     <div class="sds-card__title">{{title}}<br />
-      <span *ngIf="mainParentOfCurrentSelection" 
-        class="sds-card__subtitle" role="button" 
+      <span *ngIf="mainParentOfCurrentSelection"
+        role="list"
+        class="sds-card__subtitle"
         (click)="onMainPanelHeaderClicked($event)"
         (keyup.enter)="onMainPanelHeaderClicked($event)"
+        [attr.aria-label]="mainParentOfCurrentSelection.text + 'Press to navigate back to main list'"
         tabindex="0"
       >
         {{mainParentOfCurrentSelection.text}}


### PR DESCRIPTION
## Description
Resolves 2 issues seen in autocomplete and in selection panel components - 
In autocomplete, JAWS was announcing the drop down options icon in autocompletes as 'Clear Input'
In selection panel, JAWS was not properly announcing the aria-label of list header

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

