### PR TITLE
Resolving pathing issue for video player controls

### DIFF
--- a/libs/packages/components/src/lib/video-player/css/px-video.css
+++ b/libs/packages/components/src/lib/video-player/css/px-video.css
@@ -137,7 +137,7 @@
   width: 25px;
   height: 20px;
   margin-left: 10px;
-  background: no-repeat url("/assets/img/px-video-sprite.svg");
+  background: no-repeat url("./px-video-sprite.svg");
   background-position: -6px -907px;
 }
 .px-video-fullscreen-btn-container input[type="checkbox"]:focus + label {
@@ -167,7 +167,7 @@
   width: 25px;
   height: 20px;
   margin-left: 10px;
-  background: no-repeat url("/assets/img/px-video-sprite.svg");
+  background: no-repeat url("./px-video-sprite.svg");
   background-position: -6px -835px;
 }
 .px-video-captions-btn-container input[type="checkbox"]:focus + label {
@@ -193,7 +193,7 @@
   height: 20px;
   margin-left: 240px;
   margin-top: 2px;
-  background: no-repeat url("/assets/img/px-video-sprite.svg");
+  background: no-repeat url("./px-video-sprite.svg");
   background-position: -6px -476px;
 }
 .px-video-mute-btn-container input[type="checkbox"]:focus + label {


### PR DESCRIPTION
## Description
#544 - Sprites did appear when running locally, but failing in federalist build mainly because federalist contains non-empty string for base href. We were picking up some of the sprites from applications' assets directory rather than using a local one. Switched to using local svg file rather than the one in application's assets directory as we cannot always assume the application will have the image we need or know the path to it.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

