### PR TITLE
IAE-46051: Remove style causing issue

### DIFF
--- a/libs/packages/layouts/src/lib/feature/subheader/subheader.component.scss
+++ b/libs/packages/layouts/src/lib/feature/subheader/subheader.component.scss
@@ -6,8 +6,9 @@
       mat-button-toggle-group{
         width: 100%;
         mat-button-toggle{
-          flex: 1 1 0px;
-          -ms-flex: 1 0 auto;
+          @media screen and (max-width: 480px) {
+            flex: 1 1 0px;
+          }
           .mat-button-toggle-label-content{
             width: 100%;
             .usa-button.usa-button--outline{


### PR DESCRIPTION
## Description
Flex style was causing buttongroup to collapse down on IE, when removing it the issue resolves itself. Flex is only needed for mobile view, so updated styling so that flex is only applied for mobile.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-46051

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

