### PR TITLE
remove default queryparams handling

### DIFF
--- a/libs/packages/components/src/lib/side-navigation/side-navigation.component.html
+++ b/libs/packages/components/src/lib/side-navigation/side-navigation.component.html
@@ -21,7 +21,7 @@
 <ng-template #sideNavRouteLinkTemplate let-link>
   <a [attr.class]="link.selected ? ' usa-current' : ''" [routerLink]="[link.route]" (click)="linkClickEvent(link)"
     [queryParams]="link.queryParams" 
-    [queryParamsHandling]="link.queryParamsHandling ? link.queryParamsHandling : 'merge'">
+    [queryParamsHandling]="link.queryParamsHandling">
       <span>{{link.text}}</span>
   </a>
 </ng-template>


### PR DESCRIPTION
Reported by brandy from entity team - when navigating from sidenav to a link with no query parameters, the navigation would not remove pre-existing query params

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

