### PR TITLE
Update accordion styling

### DIFF
--- a/apps/sam-design-system-site/src/material.theme.scss
+++ b/apps/sam-design-system-site/src/material.theme.scss
@@ -137,15 +137,3 @@ $sds-mat-app-theme: mat-light-theme($sds-mat-app-primary, $sds-mat-app-accent, $
 input.mat-input-element {
   margin-top: 0.5rem !important;
 }
-
-sds-accordion-next {
-  // Add padding for displaying outline
-  .mat-expansion-panel {
-    padding: 0.25rem;
-  }
-
-  // Override material's outline of 0
-  .mat-expansion-panel-header:focus {
-    outline: 0.25rem solid #2491ff !important; 
-  }
-}

--- a/apps/sam-design-system-site/src/material.theme.scss
+++ b/apps/sam-design-system-site/src/material.theme.scss
@@ -137,3 +137,15 @@ $sds-mat-app-theme: mat-light-theme($sds-mat-app-primary, $sds-mat-app-accent, $
 input.mat-input-element {
   margin-top: 0.5rem !important;
 }
+
+sds-accordion-next {
+  // Add padding for displaying outline
+  .mat-expansion-panel {
+    padding: 0.25rem;
+  }
+
+  // Override material's outline of 0
+  .mat-expansion-panel-header:focus {
+    outline: 0.25rem solid #2491ff !important; 
+  }
+}

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.html
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.html
@@ -7,7 +7,9 @@
                 </mat-panel-title>
                 <span class="sds-expansion-indicator" [ngClass]="{'sds-expansion-indicator--expanded' : accordionItem.expanded}"></span>
             </mat-expansion-panel-header>
-            <ng-container *ngTemplateOutlet="accordionItem.itemContentTemplate"></ng-container>
+            <span [ngClass]="{'display-none': !accordionItem.expanded}">
+                <ng-container *ngTemplateOutlet="accordionItem.itemContentTemplate"></ng-container>
+            </span>
         </mat-expansion-panel>
     </ng-container>
 </mat-accordion>

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -71,10 +71,22 @@
                 }
             }
         }
+
+        // Add padding for displaying outline
+        .mat-expansion-panel {
+            padding: 0.25rem;
+        }
+
         .mat-expansion-panel-header {
             padding: 0;
             font-size: inherit !important;
         }
+
+        // Override material's outline of 0
+        .mat-expansion-panel-header:focus {
+            outline: 0.25rem solid #2491ff !important; 
+        }
+        
         .mat-expansion-panel-body {
             @include u-bg('white');
             box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 3px 0px inset;


### PR DESCRIPTION
Jira issue - https://cm-jira.usa.gov/browse/IAEDEV-46964
Github Issue #528 

## Description
Angular material sets CSS outline property of accordion headers when in focus to 0, overriding USWDS's default outline on focus. This changes overrides that override and resets it back. 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

