### PR TITLE
Update sds-filters to adjust for hideexpression configs

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -84,7 +84,8 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   _isEmpty = (obj: any): boolean => Object.keys(obj).length === 0;
   overwrite = (baseObj: any, newObj: any) => {
     const result = {};
-    for (const key in baseObj) {
+    const mergedObj = {...baseObj, ...newObj};
+    for (const key in mergedObj) {
       if (Array.isArray(baseObj[key])) {
         result[key] = newObj[key] || null;
       } else if (baseObj[key] instanceof Date) {
@@ -125,6 +126,7 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
               this.form.getRawValue(),
               filter
             );
+            this.model = updatedFormValue;
             setTimeout(() => {
               this.form.patchValue(updatedFormValue);
             });


### PR DESCRIPTION
Formly configs with hideexpression in them were not being kept on reload with history enabled. Formly does not create form controls for fields that are hidden, so when history attempts to update the filterModel using `form.patchValue` the hidden field configs are not properly set because those form controls do not get created

## Motivation and Context
#540 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

