### PR TITLE
Use provided labelText as default for autocomplete

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -4,7 +4,8 @@
       <input role="combobox" [attr.aria-expanded]="showResults"
         [attr.aria-owns]="showResults ? configuration.id + '-listbox' : undefined" aria-haspopup="listbox"
         [disabled]="disabled" (keypress)="onkeypress($event)" (input)="textChange($event)"
-        class="usa-input padding-right-3" [ngClass]="getClass()" #input [attr.aria-label]="configuration.ariaLabelText"
+        class="usa-input padding-right-3" [ngClass]="getClass()" #input 
+        [attr.aria-label]="configuration.labelText ? configuration.labelText : configuration.ariaLabelText"
         [attr.id]="configuration.id" type="text" (focus)="inputFocusHandler()" (keydown)="onKeydown($event)"
         aria-autocomplete="list" [(ngModel)]="inputValue" [attr.placeholder]="configuration.autocompletePlaceHolderText"
         [attr.aria-activedescendant]="

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -5,7 +5,7 @@
         [attr.aria-owns]="showResults ? configuration.id + '-listbox' : undefined" aria-haspopup="listbox"
         [disabled]="disabled" (keypress)="onkeypress($event)" (input)="textChange($event)"
         class="usa-input padding-right-3" [ngClass]="getClass()" #input 
-        [attr.aria-label]="configuration.labelText ? configuration.labelText : configuration.ariaLabelText"
+        [attr.aria-label]="configuration.ariaLabelText ? configuration.ariaLabelText : configuration.labelText"
         [attr.id]="configuration.id" type="text" (focus)="inputFocusHandler()" (keydown)="onKeydown($event)"
         aria-autocomplete="list" [(ngModel)]="inputValue" [attr.placeholder]="configuration.autocompletePlaceHolderText"
         [attr.aria-activedescendant]="


### PR DESCRIPTION
## Description
From JIRA ticket - https://cm-jira.usa.gov/browse/IAEDEV-46485
Updated to use labelText for aria labels if an aria label is not provided for autocomplete components

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

