### PR TITLE
Update logic in retreiving generated stackblitz files

### DIFF
--- a/libs/documentation/src/lib/components/shared/examples-page/demo.component.ts
+++ b/libs/documentation/src/lib/components/shared/examples-page/demo.component.ts
@@ -43,7 +43,21 @@ export class DocumentationWidgetDemoComponent {
   }
 
   getStackblitzLink() {
-    const filePath = `assets/stackblitzes/${this.component}/${this.id}/stackblitz.html`;
+
+    if (!this.path) {
+      throw new Error(`Demo component ${this.component} is missing path value in module setup`);
+    }
+
+    // example: path = libs/documentation/src/lib/components/search/demos/optional
+    const splitPath = this.path.split('/');
+
+    // in Example, gets 'search'
+    const outerDirectory = splitPath[splitPath.length - 3];
+
+    // in Example, gets 'optional' - assume a 'demos' directory will always be present in between
+    const innerDirectory = splitPath[splitPath.length - 1];
+    
+    const filePath = `assets/stackblitzes/${outerDirectory}/${innerDirectory}/stackblitz.html`;
     return filePath;
   }
 }


### PR DESCRIPTION
With the recent changes, I've noticed that when setting up new demos, the requirements to get it working with stackblitz was quite obscure and often tricky to get it working - with the requirements of some directory names needing to match demo names. This was because when the stackblitz demo files are generated, the script uses directory names in deciding where to place those files, while when retrieving them, runtime application logic uses the given name of the demo. This PR updates such that when retrieving the demo files during runtime, it also looks at directory names - which should make it a bit easier for new demos to be auto-integrated with stackblitz.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

