### PR TITLE
Remove default aria-label on autocomplete model

### DIFF
--- a/libs/packages/components/src/lib/autocomplete/models/SDSAutocompletelConfiguration.model.ts
+++ b/libs/packages/components/src/lib/autocomplete/models/SDSAutocompletelConfiguration.model.ts
@@ -77,7 +77,7 @@ export class SDSAutocompletelConfiguration
   /**
    * The aria-label for the auto-complete
    */
-  public ariaLabelText: string = 'Auto Complete';
+  public ariaLabelText: string;
 
   /**
    * To enable the tag mode

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -4,7 +4,7 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-radio',
   template: `
-    <div class="usa-radio" [id]="id">
+    <div class="usa-radio" [id]="id" role="radiogroup>
       <div
         *ngFor="
           let option of to.options | formlySelectOptions: field | async;

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -4,7 +4,7 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-radio',
   template: `
-    <div class="usa-radio" [id]="id" role="radiogroup>
+    <div class="usa-radio" [id]="id" role="radiogroup">
       <div
         *ngFor="
           let option of to.options | formlySelectOptions: field | async;


### PR DESCRIPTION
Current logic in autocomplete is to use the araiLabel for aria-label attribute if provided, otherwise use label text. However, since ariaLabel is assigned a default value of 'Auto Complete', the labelText property is never applied when ariaLabel is not provided by users.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

