### PR TITLE
Update Selection Panel Component

### DIFF
--- a/libs/documentation/src/lib/components/selection-panel/demos/basic/basic-selection-panel.component.html
+++ b/libs/documentation/src/lib/components/selection-panel/demos/basic/basic-selection-panel.component.html
@@ -1,7 +1,15 @@
+<div class="margin-bottom-2">
+  The base input requirements for a selection panel component is a <code>[model]</code> of type <code>SideNavigationModel</code>
+  and a <code>[title]</code> of type <code>string.</code>
 
-  <sds-selection-panel 
+  The input <code>[navigateOnClick]</code> is of type <code>boolean</code> and can be used to toggle on/off route navigation
+  when a panel item is selected.
+
+  An output event <code>(panelSelected)</code> is fired anytime a navigation item is selected with the selected <code>NavigationLink</code>
+</div>
+
+<sds-selection-panel 
   [model]="selectionPanelModel"
-  [currentSelection]="selectionPanelModel.navigationLinks[1]"
   [title]="title"
   [navigateOnClick]="false"
   (panelSelected)="onPanelSelection($event)">

--- a/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.component.html
+++ b/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.component.html
@@ -1,0 +1,12 @@
+<div class="margin-bottom-2">
+  The input <code>[currentSelection]</code> allows users to pre-select a panel item during initialization.
+  If the selected navigation link contains children, then the children items will be displayed.
+</div>
+
+<sds-selection-panel 
+[model]="selectionPanelModel"
+[title]="title"
+[currentSelection]="currentSelectedPanel">
+</sds-selection-panel>
+
+<button class="usa-button usa-button--secondary margin-top-1" (click)="onSelectExclusionsClicked()">Select Exclusions</button>

--- a/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.component.ts
+++ b/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.component.ts
@@ -1,0 +1,22 @@
+import { Component } from "@angular/core";
+import { NavigationLink, SideNavigationModel } from "@gsa-sam/components";
+import { selectionPanelConfig } from './navigation.config'
+
+
+@Component({
+  selector: `sds-default-selection-panel-demo`,
+  templateUrl: './default-selection-panel.component.html'
+})
+export class DefaultSelectionPanelComponent {
+
+  title = 'Pre-Selected Selection Panel'
+  selectionPanelModel: SideNavigationModel = selectionPanelConfig;
+  currentSelectedPanel = this.selectionPanelModel.navigationLinks[0]; // select `All Domains`
+
+  /**
+   * Update current selection panel programatically
+   */
+  onSelectExclusionsClicked() {
+    this.currentSelectedPanel = {...this.selectionPanelModel.navigationLinks[1]};
+  }
+}

--- a/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.module.ts
+++ b/libs/documentation/src/lib/components/selection-panel/demos/default-selection/default-selection-panel.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { SdsSelectionPanelModule } from "@gsa-sam/components";
+import { DefaultSelectionPanelComponent } from "./default-selection-panel.component";
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    SdsSelectionPanelModule,
+  ],
+  declarations: [
+    DefaultSelectionPanelComponent,
+  ],
+  exports: [
+    DefaultSelectionPanelComponent,
+  ],
+  bootstrap: [
+    DefaultSelectionPanelComponent
+  ]
+})
+export class DefaultSelectionPanelModule {};

--- a/libs/documentation/src/lib/components/selection-panel/demos/default-selection/navigation.config.ts
+++ b/libs/documentation/src/lib/components/selection-panel/demos/default-selection/navigation.config.ts
@@ -43,6 +43,3 @@ export let selectionPanelConfig: SideNavigationModel = {
     }
     ]
 };
-
-
-

--- a/libs/documentation/src/lib/components/selection-panel/selection-panel.module.ts
+++ b/libs/documentation/src/lib/components/selection-panel/selection-panel.module.ts
@@ -11,6 +11,8 @@ import { DocumentationSourcePage } from '../shared/source-page/source.component'
 import { DocumentationTemplatePage } from '../shared/template-page/template.component';
 import { BasicSelectionPanelComponent } from './demos/basic/basic-selection-panel.component';
 import { BasicSelectionPanelModule } from './demos/basic/basic-selection-panel.module';
+import { DefaultSelectionPanelComponent } from './demos/default-selection/default-selection-panel.component';
+import { DefaultSelectionPanelModule } from './demos/default-selection/default-selection-panel.module';
 
 declare var require: any;
 const DEMOS = {
@@ -21,6 +23,14 @@ const DEMOS = {
     module: require('!!raw-loader!./demos/basic/basic-selection-panel.module'),
     markup: require('!!raw-loader!./demos/basic/basic-selection-panel.component.html'),
     path: 'libs/documentation/src/lib/components/selection-panel/demos/basic',
+  },
+  defaultPanel: {
+    title: 'Pre-select Panel Item',
+    type: DefaultSelectionPanelComponent,
+    code: require('!!raw-loader!./demos/default-selection/default-selection-panel.component'),
+    module: require('!!raw-loader!./demos/default-selection/default-selection-panel.module'),
+    markup: require('!!raw-loader!./demos/default-selection/default-selection-panel.component.html'),
+    path: 'libs/documentation/src/lib/components/selection-panel/demos/default-selection',
   },
 };
 
@@ -52,6 +62,7 @@ export const ROUTES = [
     CommonModule,
     DocumentationComponentsSharedModule,
     BasicSelectionPanelModule,
+    DefaultSelectionPanelModule,
   ],
 })
 export class SelectionPanelModule {

--- a/libs/packages/components/src/lib/selection-panel/selection-panel.component.html
+++ b/libs/packages/components/src/lib/selection-panel/selection-panel.component.html
@@ -19,19 +19,32 @@
 
     <div class="sds-card__action sds-card__collapse"></div>
   </div>
-  <div class="sds-card__body sds-card__body--accent-cool" id="panelBody" #panelBody tabindex="-1">
-    <ul class="usa-sidenav" 
-      [ngClass]="{'usa-sidenav--styled': isTopSection, 'sds-list sds-list--subdomain': !isTopSection}">
-      <li *ngFor="let panelItem of panelItemsOnDisplay" class="usa-sidenav__item"
-        [ngClass]="{'usa-current': isTopSection && currentSelection && panelItem.id === currentSelection.id}">
-        <a href="javascript:void(0);" 
-          [ngClass]="{
-            'text-secondary': !isTopSection && (!currentSelection || panelItem.id != currentSelection.id), 
-            'usa-link usa-link--active': !isTopSection && currentSelection && panelItem.id === currentSelection.id
-          }"
-          (click)="onPanelItemClick(panelItem)">
-          {{panelItem.text}}</a>
-      </li>
-    </ul>
+
+  <!-- Move focus here after an item has been selected so that next tab press moves to panel content-->
+  <div #startOfPanelBody class="sr-only" tabindex="-1"></div>
+
+  <div class="sds-card__body sds-card__body--accent-cool" id="panelBody">
+    <ng-container *ngIf="isTopSection; else subPanel">
+      <ul class="usa-sidenav usa-sidenav--styled">
+        <li *ngFor="let panelItem of panelItemsOnDisplay" class="usa-sidenav__item"
+          [ngClass]="{'usa-current': currentSelection && panelItem.id === currentSelection.id}">
+          <a href="javascript:void(0);" (click)="onPanelItemClick(panelItem)">{{panelItem.text}}</a>
+        </li>
+      </ul>
+    </ng-container>
+
+    <ng-template #subPanel>
+      <ul class="usa-sidenav sds-list sds-list--subdomain">
+        <li *ngFor="let panelItem of panelItemsOnDisplay" class="usa-sidenav__item">
+          <a href="javascript:void(0);" 
+            [ngClass]="{
+              'text-secondary': !currentSelection || panelItem.id != currentSelection.id, 
+              'usa-link usa-link--active': currentSelection && panelItem.id === currentSelection.id
+            }"
+            (click)="onPanelItemClick(panelItem)">
+            {{panelItem.text}}</a>
+        </li>
+      </ul>
+    </ng-template>
   </div>
 </div>


### PR DESCRIPTION
Update selection panel component to allow default selection of sub panels in children array in addition to main panels and add an example for demo. Update ngOnChanges logic to allow users to programmatically update selected panel. Refactor HTML to distinguish between main panel and sub panel css.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

