### PR TITLE
Apply fix for accordions auto-closing on date validation error

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/wrappers/form-field.accordian.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/form-field.accordian.ts
@@ -44,7 +44,7 @@ export class FormlyAccordianFormFieldComponent extends FieldWrapper {
         this.formControl.value instanceof Object
           ? qs.stringify(this.formControl.value, { skipNulls: true })
           : this.formControl.value;
-      return hasValue ? true : false;
+      return hasValue || this.formControl.dirty ? true : false;
     }
   }
 }


### PR DESCRIPTION
This issue of accordion auto-closing for date was previously fixed, but for group wrappers only. This adds the fix to accordion wrappers as well

## Motivation and Context
#536 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

