### PR TITLE
Git 574 radio issue and 508 video fix

### DIFF
--- a/libs/packages/components/src/lib/video-player/css/px-video.css
+++ b/libs/packages/components/src/lib/video-player/css/px-video.css
@@ -31,6 +31,7 @@
 .px-video-progress {
   width: 100%;
   height: 10px;
+  cursor: pointer;
 }
 .px-video-progress[value] {
   /* Reset the default appearance */
@@ -304,6 +305,7 @@
   border-radius: 3px;
   color: #fff;
   width: auto;
+  bottom: 20px;
 }
 .px-timetip:after {
   top: 100%;

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation } from '@angular/core';
+import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation, Renderer2 } from '@angular/core';
 import { GLOBAL_STRINGS } from 'accessible-html5-video-player/js/strings.js';
 import * as InitPxVideo from 'accessible-html5-video-player/js/px-video.js';
 import { VPInterface } from './video-player';
@@ -29,6 +29,12 @@ export class SdsVideoPlayerComponent implements AfterViewInit {
   private config: InitPxVideoConfig;
 
   @Input() crossorigin = "";
+
+  constructor(
+    private elementRef: ElementRef,
+    private renderer2: Renderer2,
+  ) {}
+
   ngAfterViewInit() {
     if (this.crossorigin) {
       const id = document.getElementById('videoPlayer');
@@ -44,10 +50,10 @@ export class SdsVideoPlayerComponent implements AfterViewInit {
 
     new InitPxVideo(this.config);
     this.video.nativeElement.setAttribute("style", "width:"+this.VPConfiguration.width+";");
-    
-  }
 
-  constructor() {
-}
+    const progressElement: HTMLProgressElement= this.elementRef.nativeElement.querySelector('progress');
+
+    this.renderer2.setAttribute(progressElement, 'aria-label', this.VPConfiguration.description + ' progress bar');
+  }
 
 }

--- a/libs/packages/sam-formly/src/lib/formly/formly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
   FormlyModule,
   FormlyFieldConfig,
@@ -170,6 +170,7 @@ export const DATE_FORMAT: MatDateFormats = {
     ReactiveFormsModule,
     FormlySelectModule,
     SdsReadonlyModule,
+    FormsModule,
     FormlyModule.forChild(FORMLY_CONFIG),
     FormlyModule.forRoot({
       validationMessages: [

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.spec.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.spec.ts
@@ -2,7 +2,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestBed, ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Component, ViewChild } from '@angular/core';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormlyModule, FormlyForm } from '@ngx-formly/core';
 import { FormlySelectModule } from '@ngx-formly/core/select';
 import { FormlyFieldRadioComponent } from './radio';
@@ -28,6 +28,7 @@ describe('Formly Field Radio Component', () => {
         NoopAnimationsModule,
         ReactiveFormsModule,
         FormlySelectModule,
+        FormsModule,
         FormlyModule.forRoot({
           types: [
             {

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -4,20 +4,17 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-radio',
   template: `
-    <div class="usa-radio" [id]="id" role="radiogroup">
-      <div
+    <form class="usa-radio" [id]="id" role="radiogroup">
+      <ng-container
         *ngFor="
           let option of to.options | formlySelectOptions: field | async;
-          let i = index
-        "
-      >
+          let i = index">
         <input
           type="radio"
           [id]="id + '_' + i"
           class="usa-radio__input"
-          [attr.name]="id"
+          [name]="id"
           [class.usa-input--error]="showError"
-          [attr.value]="option.value"
           [value]="option.value"
           [formControl]="formControl"
           [formlyAttributes]="field"
@@ -25,8 +22,8 @@ import { FieldType } from '@ngx-formly/core';
         <label class="usa-radio__label" [for]="id + '_' + i">
           {{ option.label }}
         </label>
-      </div>
-    </div>
+      </ng-container>
+    </form>
   `,
 })
 export class FormlyFieldRadioComponent extends FieldType {


### PR DESCRIPTION
## Description
Fixes issue for radio buttons being grouped in one form. Resolves accessibility issue where AMP was flagging the progress bar in video as not having an accessible name value. Updates styling so that the timer on hover of progress bar renders properly and the cursor is the correct type.

## Motivation and Context
git #574 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

