### PR TITLE
Add aria label for external links

### DIFF
--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -8,9 +8,9 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 @Component({
   template: `
     <a id="test" href="google.com">Google </a>
-    <a id="test" [hideIcon]="true" href="google.com">Google </a>
-    <a id="test2">Not Google </a>
-    <a id="test" href="{{name}}/settings/test123">Google </a>
+    <a id="test2" [hideIcon]="true" href="google.com" aria-label="test aria label">Google </a>
+    <a id="test3">Not Google </a>
+    <a id="test4" href="{{name}}/settings/test123">Google </a>
   `
 })
 class TestComponent {
@@ -44,15 +44,31 @@ describe('Sam External Link Directive', () => {
 
   it('should create one icon', () => {
     fixture.detectChanges();
-    const cmp = fixture.debugElement.query(By.css('#test'));
     const icons = findIcons();
     expect(icons.length).toEqual(1);
   });
 
   it('should not create an icon', () => {
     fixture.detectChanges();
-    const cmp = fixture.debugElement.query(By.css('#test2'));
     const icons = findIcons();
     expect(icons.length).toEqual(1);
   });
+
+  it ('Showd add aria label attribute to external links if one does not exist', () => {
+    fixture.detectChanges();
+    const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test'));
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open google.com in a new window');
+  });
+
+  it('Should not add aria label to external link if one is already provided', () => {
+    fixture.detectChanges();
+    const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test2'));
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('test aria label');
+  });
+
+  it('Should not add aria label to internal links', () => {
+    fixture.detectChanges();
+    const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test4'));
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('');
+  })
 });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -47,6 +47,13 @@ export class ExternalLinkDirective implements OnChanges {
       }
       this.relAttr = 'noopener';
       this.targetAttr = '_blank';
+    }
+
+    /**
+     * Add aria label warning users the link will open a new window if the anchor tag
+     * does not already have an aria label
+     */
+    if (this.targetAttr === '_blank') {
       const currentAriaLabel = this.el.nativeElement.getAttribute('aria-label');
       if (!currentAriaLabel || currentAriaLabel.length === 0) {
         this.ariaLabel = `Open ${this.href} in a new window`;

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -7,6 +7,7 @@ import {
   Input,
   ViewContainerRef,
   OnChanges,
+  AfterViewInit,
 } from '@angular/core';
 
 import { isPlatformBrowser } from '@angular/common';
@@ -18,8 +19,13 @@ export class ExternalLinkDirective implements OnChanges {
   @HostBinding('attr.rel') relAttr = '';
   @HostBinding('attr.target') targetAttr = '';
   @HostBinding('attr.href') hrefAttr = '';
+  @HostBinding('attr.aria-label') ariaLabel = '';
+
+
   @Input() href: string;
   @Input() target: string;
+
+
   @Input() public hideIcon: boolean = false;
   private internalLinks = ['fsd.gov'];
 
@@ -32,6 +38,7 @@ export class ExternalLinkDirective implements OnChanges {
   public ngOnChanges() {
     this.hrefAttr = this.href;
     this.targetAttr = this.target;
+
     if (!this.isExternalLink) {
       return;
     } else {
@@ -40,6 +47,10 @@ export class ExternalLinkDirective implements OnChanges {
       }
       this.relAttr = 'noopener';
       this.targetAttr = '_blank';
+      const currentAriaLabel = this.el.nativeElement.getAttribute('aria-label');
+      if (!currentAriaLabel || currentAriaLabel.length === 0) {
+        this.ariaLabel = `Open ${this.href} in a new window`;
+      }
     }
   }
 


### PR DESCRIPTION
Amp flags external links that don't warn the users when a link will open new window, so this change updates the external link directive to add an aria label to notify the users. The label is only added if an aria label does not already exist in the link.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

