### PR TITLE
Update pagination input to include total pages

### DIFF
--- a/libs/packages/components/src/lib/pagination/pagination.component.html
+++ b/libs/packages/components/src/lib/pagination/pagination.component.html
@@ -5,6 +5,7 @@
       [attr.for]="paginationConfiguration.id + '-currentPage'">Current Page</label>
     <input [attr.id]="paginationConfiguration.id +'-currentPage'"
       class="usa-input usa-input--small font-sans-3xs text-center border-base-light" #currentPage
+      [attr.aria-label]="'Page ' + page.pageNumber + ' of ' + page.totalPages"
       (ngModelChange)="valuechange($event)" [(ngModel)]="page.pageNumber" type="number" min="1"
       [(attr.max)]="page.totalPages" (focusout)="currentPageFocusOut()" [ngStyle]="{'width': (20 + page.totalPages.toString().length * 10) +'px'}" />
     <span class="sds-pagination__total">

--- a/libs/packages/layouts/src/lib/feature/actions-menu/actions-menu.component.html
+++ b/libs/packages/layouts/src/lib/feature/actions-menu/actions-menu.component.html
@@ -11,7 +11,7 @@
     [icon]="['sds', 'ellipsis']"
     transform="grow-5"
   ></fa-icon>
-  <span class="usa-sr-only">Toggle Actions Menu</span>
+  <span class="usa-sr-only">Toggle Actions</span>
 </button>
 
 <!-- Menu content -->


### PR DESCRIPTION
Updates pagination component's input so that it also announces total pages to the user on focus.
Updates menu component's sr only message to not include the word 'Menu' as it is added by screen readers for buttons with role="menu"

## Motivation and Context
git #585 
git #588 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

