### PR TITLE
update card expand/collapse toggle for responsive layout

### DIFF
--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
@@ -22,11 +22,11 @@
             </div>
           </div>
 
-          <div class="sds-card sds-card--collapsible" [ngClass]="{'sds-card--collapsed': filtersExpanded}">
-            <div role="button" class="sds-card__header sds-card__header--action" [attr.aria-expanded]="!filtersExpanded"
+          <div class="sds-card sds-card--collapsible" [ngClass]="{'sds-card--collapsed': !domainsExpanded}">
+            <div role="button" class="sds-card__header sds-card__header--action" [attr.aria-expanded]="domainsExpanded"
             aria-controls="panelBody" tabindex="0" aria-label="Select Domain"
-            (click)="filtersExpanded = !filtersExpanded"
-            (keyup.enter)="filtersExpanded = !filtersExpanded"
+            (click)="domainsExpanded = !domainsExpanded"
+            (keyup.enter)="domainsExpanded = !domainsExpanded"
             >
               <div class="sds-card__title">Select Domain<br />
                 <span class="sds-card__subtitle">
@@ -47,7 +47,7 @@
             </div>
           </div>
 
-          <div class="sds-card" *ngIf="selectedPanel && selectedPanel.children">
+          <div class="sds-card" *ngIf="selectedPanel && selectedPanel.children" [ngClass]="{'display-none': domainsExpanded}">
             <div class="sds-card__body sds-card__body--accent-cool">
               <sds-sub-panel [model]="selectedPanel.children" (subPanelClicked)="onSubPanelClicked($event)"></sds-sub-panel>
             </div>

--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
@@ -23,7 +23,8 @@ export class LayoutResponsiveComponent {
   form;
   filterModel = {};
   options;
-  filtersExpanded: boolean = true;
+  filtersExpanded: boolean = false;
+  domainsExpanded: boolean = true;
 
   public filterChange$ = new BehaviorSubject<object>([]);
   public navigationModel: SelectionPanelModel = {
@@ -117,6 +118,7 @@ export class LayoutResponsiveComponent {
 
   onPanelSelection($event: NavigationLink) {
     this.selectedPanel = $event;
+    this.domainsExpanded = false;
     this.filtersExpanded = true;
     console.log('Selected Domain', $event);
     this.router.navigate(


### PR DESCRIPTION
Small update to demo for responsive layout component - separate the variable used for card expand/collapse for domain and filters  so that they can be controlled separately

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

