### PR TITLE
Update sds filters to allow users to pass in default model

### DIFF
--- a/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.component.html
+++ b/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.component.html
@@ -1,0 +1,12 @@
+<h6>API reference for SDS Filter</h6>
+<p><code>import SdsFiltersModule from '@gsa-sam/sam-formly';</code></p>
+<p><code>import SdsFormlyModule from '@gsa-sam/sam-formly';</code></p>
+
+<div class="margin-bottom-2">
+  The input of <code>[defaultModel]</code> allows you to define what values to reset the form to
+  when 'Reset All' is clicked. If this is not provided, then the value used will be either the initial
+  model values during formly's init or the defaultValue property in formly's config - in that order of
+  priority.
+</div>
+
+<sds-filters [form]="form" [fields]="fields" [model]="model" [defaultModel]="defaultModel"></sds-filters>

--- a/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.component.ts
@@ -1,0 +1,33 @@
+import { Component } from "@angular/core";
+import { FormGroup } from "@angular/forms";
+import { FormlyFieldConfig, FormlyFormOptions } from "@ngx-formly/core";
+
+
+@Component({
+  selector: `sds-filters-default-value-demo`,
+  templateUrl: './filters-default-value.component.html'
+})
+export class FiltersDefaultValueComponent {
+  form = new FormGroup({});
+  model: any = {
+    title: 'Acme Corporation'
+  };
+
+  // Values you'd like the form to be reset to when reset all is slicked
+  defaultModel: any = {
+    title: 'All Entities'
+  };
+
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        placeholder: 'Acme Corporation',
+        description: 'Enter the name of your entity.',
+        required: true,
+      },
+    },
+  ];
+}

--- a/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.module.ts
+++ b/libs/documentation/src/lib/components/filters/demos/defaultValues/filters-default-value.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { SdsFiltersModule, SdsFormlyModule } from "@gsa-sam/sam-formly";
+import { FormlyModule } from "@ngx-formly/core";
+import { FiltersDefaultValueComponent } from "./filters-default-value.component";
+
+@NgModule({
+  imports: [    
+    CommonModule,
+    FormsModule,
+    SdsFiltersModule,
+    FormlyModule.forRoot(),
+    ReactiveFormsModule,
+  ],
+  declarations: [FiltersDefaultValueComponent],
+  exports: [FiltersDefaultValueComponent],
+  bootstrap: [FiltersDefaultValueComponent]
+})
+export class FiltersDefaultValueModule {}

--- a/libs/documentation/src/lib/components/filters/filters.module.ts
+++ b/libs/documentation/src/lib/components/filters/filters.module.ts
@@ -17,6 +17,8 @@ import { FiltersShowInactiveFilterValues } from './demos/showInactiveFilterValue
 import { FiltersShowInactiveFilterValuesModule } from './demos/showInactiveFilterValues/filters-showInactiveFilterValues.module';
 import { FiltersGroupPanel } from './demos/group-panel/filters-group-panel.component';
 import { FiltersGroupPanelModule } from './demos/group-panel/filters-group-panel.module';
+import { FiltersDefaultValueComponent } from './demos/defaultValues/filters-default-value.component';
+import { FiltersDefaultValueModule } from './demos/defaultValues/filters-default-value.module';
 
 declare var require: any;
 const DEMOS = {
@@ -53,6 +55,15 @@ const DEMOS = {
     path:
       'libs/documentation/src/lib/components/filters/demos/showInactiveFilterValues',
   },
+  defaultValues: {
+    title: 'DeaultModel',
+    type: FiltersDefaultValueComponent,
+    code: require('!!raw-loader!./demos/defaultValues/filters-default-value.component'),
+    markup: require('!!raw-loader!./demos/defaultValues/filters-default-value.component.html'),
+    module: require('!!raw-loader!./demos/defaultValues/filters-default-value.module'),
+    path:
+      'libs/documentation/src/lib/components/filters/demos/defaultValues',
+  },
 };
 
 export const ROUTES = [
@@ -86,6 +97,7 @@ export const ROUTES = [
     FiltersHideExpressionModule,
     FiltersGroupPanelModule,
     FiltersShowInactiveFilterValuesModule,
+    FiltersDefaultValueModule,
   ],
 })
 export class FiltersModule {

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -7,6 +7,6 @@
     </sds-advanced-filters>
   </div>
   <div class="grid-col text-right">
-    <sds-formly-reset [options]="options"></sds-formly-reset>
+    <sds-formly-reset [options]="options" [defaultModel]="defaultModel"></sds-formly-reset>
   </div>
 </div>

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.spec.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.spec.ts
@@ -298,5 +298,30 @@ describe('The Sam Filters Component', () => {
       fixture.detectChanges();
       expect(component.fields[0].hide).toBe(true);
     });
+
+    it('Should reset to given defaultModel if provided', () => {
+      component.fields = [
+        {
+          key: 'filters',
+          type: 'input',
+          hide: true,
+          templateOptions: {
+            label: 'State',
+            description: 'State'
+          }
+        }
+      ];
+
+      component.model = {filters: '12345'};
+      component.defaultModel = {filters: '67890'};
+
+      fixture.detectChanges();
+
+      const resetAllButton = fixture.debugElement.query(By.css('button'));
+      resetAllButton.triggerEventHandler('click', null);
+      fixture.detectChanges();
+      expect(component.model).toEqual({filters: '67890'});
+
+    })
   });
 });

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -74,6 +74,15 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   @Input() public getCleanModel: boolean = false;
 
   /**
+   * Default values to reset form to when reset is done
+   * If not passed in, then default values will be values
+   * assigned to the model input during component init
+   * or defaultValue provided in formly config
+   */
+  @Input() defaultModel: any;
+
+
+  /**
    *  Emit results when model updated
    */
   // TODO: check type -- Formly models are typically objects

--- a/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.ts
@@ -14,6 +14,8 @@ export class SdsFormlyResetComponent {
    */
   @Input() options: FormlyFormOptions;
 
+  @Input() defaultModel: any;
+
   /**
    * Pass in classes for reset button -- default .usa-button .usa-button--unstyled
    */
@@ -21,7 +23,12 @@ export class SdsFormlyResetComponent {
 
   constructor(library: FaIconLibrary) { library.addIconPacks(fas, sds); }
   resetAll() {
-    this.options.resetModel();
+
+    if (this.defaultModel) {
+      this.options.resetModel(this.defaultModel);
+    } else {
+      this.options.resetModel();
+    }
   }
 
 }


### PR DESCRIPTION
## Description
With responsive layout introduced, sds filters is initialized anytime advanced search is clicked, and destroyed anytime the responsive modal closes. During init, formly uses current model values to define what the initial values are to reset the form back to when users do resetModel. The issue with resetAll occurs because opening the responsive model, entering some values, applying those values, then re-opening the model changes what the default values for sds filters' formly are because the form gets re-initialized, but with default values of whatever the current model is. This change adds an input to sds filters for developers to pass in the default values to reset to and allows for a separation of what the model is during formly initialization vs what the values should be on form reset.

## Motivation and Context
git #594 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

