### PR TITLE
Perform shallow copy of model on filter change rather than changing model reference

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -126,7 +126,12 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
               this.form.getRawValue(),
               filter
             );
-            this.model = updatedFormValue;
+            
+            // Shallow copy to not trigger onChanges from formly side
+            Object.keys(updatedFormValue).forEach(key => {
+              this.model[key] = updatedFormValue[key];
+            });
+
             setTimeout(() => {
               this.form.patchValue(updatedFormValue);
             });


### PR DESCRIPTION
## Description
Issue discovered by atomic tangerine and recorded in this git ticket - #609 
This issue was caused as a result of fix for this git issue - #540 - The change there had re-assigned the model to updatedModel to account for hideExpression filters. The issue this caused is that because the reference to model changed, formly rebuilt it's form from it's ngOnChanges - https://github.com/ngx-formly/ngx-formly/blob/main/src/core/src/lib/components/formly.form.ts#L81 - which caused the perceived default value to update, and break resetAll functionality.

This update keeps the copy of the updatedModel to sds filters' model, but does so without changing reference. This way, ngOnChanges is not triggered, and formly does not re-build its form

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

