### PR TITLE
Add output event when an alert is dismissed

### DIFF
--- a/libs/documentation/src/lib/components/system-alerts/demos/multiple/system-alerts-multiple.component.html
+++ b/libs/documentation/src/lib/components/system-alerts/demos/multiple/system-alerts-multiple.component.html
@@ -1,3 +1,4 @@
 
   <sds-system-alert *ngIf="alerts && alerts.length" 
-  [alerts]="alerts" (seeAllAlerts)="onSeeAllAlerts()" (detailsClicked)="onShowDetailsClicked($event)"></sds-system-alert>
+  [alerts]="alerts" (seeAllAlerts)="onSeeAllAlerts()" (detailsClicked)="onShowDetailsClicked($event)"
+  (alertDismiss)="onAlertDismiss($event)"></sds-system-alert>

--- a/libs/documentation/src/lib/components/system-alerts/demos/multiple/system-alerts-multiple.component.ts
+++ b/libs/documentation/src/lib/components/system-alerts/demos/multiple/system-alerts-multiple.component.ts
@@ -32,4 +32,8 @@ export class SystemAlertsMultipleComponent {
   onShowDetailsClicked(alert: Alert) {
     console.log('Show details for alert', alert);
   }
+
+  onAlertDismiss(alert: Alert) {
+    console.log('Alert dismissed: ', alert);
+  }
 }

--- a/libs/documentation/src/lib/components/system-alerts/demos/single/system-alerts-single.component.html
+++ b/libs/documentation/src/lib/components/system-alerts/demos/single/system-alerts-single.component.html
@@ -1,3 +1,4 @@
 
   <sds-system-alert *ngIf="alerts && alerts.length" 
-  [alerts]="alerts" (seeAllAlerts)="onSeeAllAlerts()" (detailsClicked)="onShowDetailsClicked($event)"></sds-system-alert>
+  [alerts]="alerts" (seeAllAlerts)="onSeeAllAlerts()" (detailsClicked)="onShowDetailsClicked($event)" 
+  (alertDismiss)="onAlertDismiss($event)"></sds-system-alert>

--- a/libs/documentation/src/lib/components/system-alerts/demos/single/system-alerts-single.component.ts
+++ b/libs/documentation/src/lib/components/system-alerts/demos/single/system-alerts-single.component.ts
@@ -23,4 +23,8 @@ export class SystemAlertsSingleComponent {
     console.log('Show details for alert', alert);
   }
 
+  onAlertDismiss(alert: Alert) {
+    console.log('Alert dismissed: ', alert);
+  }
+
 }

--- a/libs/packages/layouts/src/lib/feature/system-alert/system-alert.component.ts
+++ b/libs/packages/layouts/src/lib/feature/system-alert/system-alert.component.ts
@@ -17,6 +17,8 @@ export class SdsSystemAlertComponent {
 
   @Output() detailsClicked = new EventEmitter<Alert>();
 
+  @Output() alertDismiss = new EventEmitter<Alert>();
+
   constructor() { }
 
   /**
@@ -24,7 +26,9 @@ export class SdsSystemAlertComponent {
    * @param index - index of the alert in array to remove
    */
   onAlertClose(index: number) {
+    const dismissedAlert = this.alerts[index];
     this.alerts.splice(index, 1);
+    this.alertDismiss.emit(dismissedAlert);
   }
 
   /**


### PR DESCRIPTION
## Description
Adds output event when an alert is dismissed so that applications are able to keep track of dismissed alerts and not re-render on page refresh


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

