### PR TITLE
Remove aria-label default from autocomplete-search-configuration

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/models/SDSAutocompleteConfiguration.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/models/SDSAutocompleteConfiguration.ts
@@ -73,7 +73,7 @@ export class SDSAutocompleteSearchConfiguration {
   /**
    * The aria-label for the auto-complete
    */
-  public ariaLabelText: string = 'Auto Complete';
+  public ariaLabelText: string;
 
   /**
    * To enable the tag mode


### PR DESCRIPTION
The ariaLabel default was previously removed for autocompleteconfiguration model and merged in - https://github.com/GSA/sam-design-system/commit/f9da43f72cc29718ca05f22cf28bdfb10069159b#diff-6f0ecbedcda2523749a35b93eb7df9740cc94e5cde919b4a63360d62f3a2933d
However, we have another similar model `SDSAutocompleteSearchConfiguration` for which the ariaLabelText default string was not removed

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

