### PR TITLE
Disable css changes for Input and label

### DIFF
--- a/libs/documentation/src/lib/components/formly-input/demos/optional/input-optional.component.ts
+++ b/libs/documentation/src/lib/components/formly-input/demos/optional/input-optional.component.ts
@@ -7,7 +7,6 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   styleUrls: ['./input-optional.component.scss'],
   selector: `sds-formly-input-optional-demo`,
 })
-
 export class InputOptional {
   form = new FormGroup({});
   model: any = {};
@@ -19,7 +18,18 @@ export class InputOptional {
       templateOptions: {
         label: 'Reference Number',
         placeholder: 'A123456',
-        description: 'If you have your own reference number you can add it here.'
+        description:
+          'If you have your own reference number you can add it here.',
+      },
+    },
+    {
+      key: 'search',
+      type: 'input',
+      templateOptions: {
+        label: 'Search',
+        placeholder: 'A123456',
+        disabled: true,
+        description: 'Type here to search',
       },
     },
   ];

--- a/libs/packages/sam-formly/src/lib/formly/types/input.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/input.ts
@@ -4,7 +4,18 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-input',
   template: `
-  <input [class.usa-input--error]="showError" class="usa-input" [placeholder]="to.placeholder" name="input-success" [formlyAttributes]="field" [type]="to.inputType? to.inputType : 'text'" [formControl]="formControl">
+    <input
+      [ngClass]="{
+        'usa-input--disabled': to.disabled,
+        'usa-input--error': showError
+      }"
+      class="usa-input"
+      [placeholder]="to.placeholder"
+      name="input-success"
+      [formlyAttributes]="field"
+      [type]="to.inputType ? to.inputType : 'text'"
+      [formControl]="formControl"
+    />
   `,
 })
-export class FormlyFieldInputComponent extends FieldType { }
+export class FormlyFieldInputComponent extends FieldType {}

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/description.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/description.wrapper.ts
@@ -7,9 +7,15 @@ import { FieldWrapper } from '@ngx-formly/core';
 @Component({
   template: `
     <div>
-      <small *ngIf="to.description" class="form-text text-muted" [id]="id+ '-description'">{{
-        to.description
-      }}</small>
+      <small
+        *ngIf="to.description"
+        class="form-text text-muted"
+        [id]="id + '-description'"
+        [ngClass]="{
+          'usa-label--disabled': to.disabled
+        }"
+        >{{ to.description }}</small
+      >
       <ng-container #fieldComponent></ng-container>
     </div>
   `,

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/label.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/label.wrapper.ts
@@ -20,7 +20,8 @@ import { FieldWrapper } from '@ngx-formly/core';
           'usa-sr-only':
             to.hideLabel ||
             ((to.group === 'panel' || to.group === 'accordion') &&
-              field?.parent?.type !== 'formly-group')
+              field?.parent?.type !== 'formly-group'),
+          'usa-label--disabled': to.disabled
         }"
       >
         <span


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

