### PR TITLE
fixes for github issues 622, 621, and 619

### DIFF
--- a/libs/packages/components/src/lib/search/search.component.html
+++ b/libs/packages/components/src/lib/search/search.component.html
@@ -40,9 +40,9 @@
         </sds-icon>
       </span>
     </span>
-    <button *ngIf="!searchSettings.isSuffixSearchIcon" #buttonEl class="usa-button" type="submit"
+    <button *ngIf="!searchSettings.isSuffixSearchIcon" #buttonEl class="usa-button" type="submit" 
+      [attr.aria-label]="searchSettings.ariaLabel ? searchSettings.ariaLabel : 'Search'"
       (click)="handleClick($event)">
-      <span class="usa-sr-only">Search</span>
     </button>
   </div>
 

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -4,8 +4,8 @@ import { FieldType } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-radio',
   template: `
-    <form class="usa-radio" [id]="id" role="radiogroup" 
-      [attr.aria-label]="to.label" [attr.aria-describedby]="id + '-description'">
+    <form class="usa-radio" [id]="id"
+      [attr.aria-label]="to.ariaLabel? to.ariaLabel : to.label" [attr.aria-describedby]="id + '-description'">
       <ng-container
         *ngFor="
           let option of to.options | formlySelectOptions: field | async;

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -218,3 +218,11 @@
 mat-panel-title {
     line-height: 25px;
 }
+
+.mat-expansion-panel-header {
+    min-height: 48px;
+}
+  
+.mat-expansion-panel-header, .mat-expansion-panel-header.mat-expanded {
+    height: auto;
+}


### PR DESCRIPTION
## Description
Resolves various github issues:
#622 - Adjusts height for accordion header to allow larger texts in accordion heading
#621 - Removes role of radio group from radio form element as it was being flagged by access assistant
#619 - Removes sr-only label for search button and instead uses aria label for screen readers

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

