### PR TITLE
Update min height of accordion

### DIFF
--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -220,7 +220,7 @@ mat-panel-title {
 }
 
 .mat-expansion-panel-header {
-    min-height: 48px;
+    min-height: 34px;
 }
   
 .mat-expansion-panel-header, .mat-expansion-panel-header.mat-expanded {


### PR DESCRIPTION
## Description
There was slightly more space added for min-height than needed on a previous change where the text on accordion header was cutting off - https://github.com/GSA/sam-design-system/issues/622
This change re-adjusts the height of accordion header back down to 34 px

## Motivation and Context
https://github.com/GSA/sam-design-system/issues/622

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/73653244/111184281-30c18480-8587-11eb-96de-dfcd70b69e05.png)

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

