### PR TITLE
Hideoptional should not display optional label for daterange picker

### DIFF
--- a/libs/documentation/src/lib/components/formly-datepicker/demos/daterange/datepicker-daterange.component.ts
+++ b/libs/documentation/src/lib/components/formly-datepicker/demos/daterange/datepicker-daterange.component.ts
@@ -25,7 +25,8 @@ export class FormlyDatepickerDateRange {
           day: 'numeric',
           year: 'numeric'
         }),
-      }
+        hideOptional: true,
+      },
     }
   ];
 

--- a/libs/packages/sam-formly/src/lib/formly/formly.config.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.config.ts
@@ -1,4 +1,4 @@
-import { ConfigOption, FormlyFieldConfig } from '@ngx-formly/core';
+import { ConfigOption, Field, FormlyFieldConfig } from '@ngx-formly/core';
 import { FormlyWrapperFormFieldComponent } from './wrappers/form-field.wrapper';
 import { FormlyAccordianFormFieldComponent } from './wrappers/form-field.accordian';
 import { FormlyFormFieldFilterWrapperComponent } from './wrappers/form-field.filterwrapper';
@@ -183,11 +183,14 @@ export const FORMLY_CONFIG: ConfigOption = {
                 month: 'short',
                 day: 'numeric',
                 year: 'numeric'
-              })
+              }),
             },
             expressionProperties: {
               'templateOptions.minDate': minDateFromDateRangePicker,
-              'templateOptions.maxDate': maxDateFromDateRangePicker
+              'templateOptions.maxDate': maxDateFromDateRangePicker,
+              'templateOptions.hideOptional': (model, formState, field) => {
+                return field.parent.templateOptions.hideOptional;
+              },
             }
           },
           {
@@ -203,8 +206,10 @@ export const FORMLY_CONFIG: ConfigOption = {
             },
             expressionProperties: {
               'templateOptions.minDate': minDateToDateRangePicker,
-              'templateOptions.maxDate': maxDateToDateRangePicker
-            }
+              'templateOptions.maxDate': maxDateToDateRangePicker,
+              'templateOptions.hideOptional': (model, formState, field) => {
+                return field.parent.templateOptions.hideOptional;
+              },            }
           }
         ]
       }


### PR DESCRIPTION
## Description
Setting hideoptional to true should hide optional in label for daterangepicker

## Motivation and Context
#642 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

