### PR TITLE
Move hideoptional method into exported function for date range picker

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/formly.config.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.config.ts
@@ -188,9 +188,7 @@ export const FORMLY_CONFIG: ConfigOption = {
             expressionProperties: {
               'templateOptions.minDate': minDateFromDateRangePicker,
               'templateOptions.maxDate': maxDateFromDateRangePicker,
-              'templateOptions.hideOptional': (model, formState, field) => {
-                return field.parent.templateOptions.hideOptional;
-              },
+              'templateOptions.hideOptional': getParentHideOptional,
             }
           },
           {
@@ -207,9 +205,8 @@ export const FORMLY_CONFIG: ConfigOption = {
             expressionProperties: {
               'templateOptions.minDate': minDateToDateRangePicker,
               'templateOptions.maxDate': maxDateToDateRangePicker,
-              'templateOptions.hideOptional': (model, formState, field) => {
-                return field.parent.templateOptions.hideOptional;
-              },            }
+              'templateOptions.hideOptional': getParentHideOptional,     
+            }
           }
         ]
       }
@@ -326,4 +323,16 @@ export function maxDateFromDateRangePicker(
     }
   }
   return date;
+}
+
+export function getParentHideOptional(
+  model: any,
+  formState: any,
+  field: FormlyFieldConfig
+) {
+
+  if (field.parent && field.parent.templateOptions) {
+    return field.parent.templateOptions.hideOptional;
+  }
+  return false;
 }


### PR DESCRIPTION
## Description
Moves hideoptional expression for date range picker to exported function to allow prod build.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

