### PR TITLE
Resolve height issue for accordion in ie

### DIFF
--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -39,7 +39,6 @@
         .mat-expansion-panel-header {
             padding: 0 1em;
             min-height: 34px;
-
         }
 
         .mat-expansion-panel-header, .mat-expansion-panel-header.mat-expanded {

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -38,7 +38,14 @@
         }
         .mat-expansion-panel-header {
             padding: 0 1em;
+            min-height: 34px;
+
         }
+
+        .mat-expansion-panel-header, .mat-expansion-panel-header.mat-expanded {
+            height: auto;
+        }
+        
         .mat-expansion-panel-body {
             padding: 0 1em 1em;
         }
@@ -217,12 +224,4 @@
 
 mat-panel-title {
     line-height: 25px;
-}
-
-.mat-expansion-panel-header {
-    min-height: 34px;
-}
-  
-.mat-expansion-panel-header, .mat-expansion-panel-header.mat-expanded {
-    height: auto;
 }


### PR DESCRIPTION

## Description
From github issue #632 - Accordion items are not properly aligned in IE

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

