### PR TITLE
Add dialog config option for side toolbar

### DIFF
--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
@@ -8,7 +8,11 @@
 <div class="sds-page condensed margin-top-2">
   <div class="grid-container grid-row grid-gap">
     <div class="desktop:grid-col-4 tablet-lg:grid-col-12 mobile-lg:grid-col-12 margin-bottom-3">
-      <sds-side-toolbar (responsiveDialog)="onDialogOpen($event)" (responsiveView)="isMobileMode = $event;" [responsiveButtonText]="'Advanced Search'">
+      <sds-side-toolbar
+        [responsiveButtonText]="'Advanced Search'"
+        [responsiveDialogOptions]="responsiveDialogOptions"
+        (responsiveDialog)="onDialogOpen($event)" 
+        (responsiveView)="isMobileMode = $event;">
         <ng-template #toolbarContent>
           <div class="sds-card" *ngIf="isMobileMode">
             <div class="sds-card__header sds-card__header--accent-cool grid-row">
@@ -37,7 +41,7 @@
               <div class="sds-card__action sds-card__collapse"></div>
             </div>
             
-            <div class="sds-card__body sds-card__body--accent-cool">
+            <div class="sds-card__body sds-card__body--accent-cool" id="panelBody">
               <sds-selection-panel 
               [model]="navigationModel"
               [currentSelection]="selectedPanel"

--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NavigationLink, SdsDialogRef, SelectionPanelModel } from '@gsa-sam/components';
+import { NavigationLink, SdsDialogConfig, SdsDialogRef, SelectionPanelModel } from '@gsa-sam/components';
 import { SearchListConfiguration } from '@gsa-sam/layouts';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { SdsFiltersComponent } from 'libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component';
@@ -25,6 +25,9 @@ export class LayoutResponsiveComponent {
   options;
   filtersExpanded: boolean = false;
   domainsExpanded: boolean = true;
+  responsiveDialogOptions: SdsDialogConfig = {
+    ariaLabel: 'Search Filters',
+  };
 
   public filterChange$ = new BehaviorSubject<object>([]);
   public navigationModel: SelectionPanelModel = {

--- a/libs/packages/components/src/lib/public-api.ts
+++ b/libs/packages/components/src/lib/public-api.ts
@@ -41,6 +41,7 @@ export * from './tab-outside/taboutside.directive';
 export * from './click-outside/click-outside.module';
 export * from './click-outside/click-outside.directive';
 export * from './dialog/dialog';
+export * from './dialog/dialog-config';
 export * from './dialog/dialog-ref';
 export * from './dialog/dialog.module';
 export * from './dialog/dialog-container.component';

--- a/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
+++ b/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
@@ -11,6 +11,7 @@ import {
 import { SdsDialogRef, SdsDialogService } from '@gsa-sam/components';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { Subscription } from 'rxjs';
+import { SdsDialogConfig } from '@gsa-sam/components';
 
 @Component({
   selector: 'sds-side-toolbar',
@@ -22,6 +23,8 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
 
   // Text for button in responsive view
   @Input() responsiveButtonText: string;
+
+  @Input() responsiveDialogOptions: SdsDialogConfig
 
   // default value is size of mobile view in px
   @Input() responsiveSize = 480;
@@ -48,15 +51,19 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
   }
 
   onResponsiveViewButtonClicked() {
-    this.openResponsiveDialog = this.sdsDialogService.open(this.template, {
+    let dialogOptions = {
       height: '100vh',
       width: '100vw',
       maxWidth: '100vw',
       maxHeight: '100vh',
       hasBackdrop: false,
       displayCloseBtn: false,
-      panelClass: ['sds-dialog--full'],
-    });
+      panelClass: ['sds-dialog--full']
+    };
+
+    let allOptions = this.responsiveDialogOptions ? {...this.responsiveDialogOptions, ...dialogOptions} : dialogOptions;
+
+    this.openResponsiveDialog = this.sdsDialogService.open(this.template, allOptions);
 
     this.responsiveDialog.emit(this.openResponsiveDialog);
   }

--- a/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
+++ b/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
@@ -61,7 +61,7 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
       panelClass: ['sds-dialog--full']
     };
 
-    let allOptions = this.responsiveDialogOptions ? {...this.responsiveDialogOptions, ...dialogOptions} : dialogOptions;
+    let allOptions = this.responsiveDialogOptions ? {...dialogOptions, ...this.responsiveDialogOptions} : dialogOptions;
 
     this.openResponsiveDialog = this.sdsDialogService.open(this.template, allOptions);
 


### PR DESCRIPTION
## Description
From github issue #650 - Updated to allow users to pass in dialog options for responsive toolbar.

## Motivation and Context
Allowing users to pass in dialog options would let them define certain properties of the responsive dialog modal - including aria label

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

