### PR TITLE
Update accordion css, reset filter on layout destroy, auto close responsive modal on window resize

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -154,6 +154,9 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
   }
 
   ngOnDestroy() {
+    // Reset filter Model in update service
+    this.filterUpdateModelService.updateModel(null);
+    
     if (this.formlySubscription) {
       this.formlySubscription.unsubscribe();
     }

--- a/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
+++ b/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
@@ -59,6 +59,10 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
     });
 
     this.responsiveDialog.emit(this.openResponsiveDialog);
+
+    this.openResponsiveDialog.afterClosed().subscribe(() => {
+      this.openResponsiveDialog = undefined;
+    })
   }
 
   private observeViewChange() {
@@ -69,7 +73,7 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
           this.isResponsiveView = true;
         } else {
           this.isResponsiveView = false;
-          if (this.openResponsiveDialog && this.openResponsiveDialog.componentInstance) {
+          if (this.openResponsiveDialog) {
             this.openResponsiveDialog.close();
             this.openResponsiveDialog = undefined;
             this.responsiveDialog.emit(this.openResponsiveDialog);

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -16,12 +16,12 @@
                 box-sizing: border-box;
                 &:first-of-type {
                     @include u-border-top('1px');
-                    border-top-left-radius: 0;
-                    border-top-right-radius: 0;
+                    border-top-left-radius: 0.25rem;
+                    border-top-right-radius: 0.25rem;
                 }
                 &:last-of-type {
-                    border-bottom-left-radius: 0;
-                    border-bottom-right-radius: 0;
+                    border-bottom-left-radius: 0.25rem;
+                    border-bottom-right-radius: 0.25rem;
                 }
                 .mat-expanded {
                     sds-accordion-title {
@@ -159,6 +159,12 @@
     .sds-accordion--filters .mat-expansion-panel .mat-expansion-panel-header.cdk-program-focused:not([aria-disabled=true]),
     .sds-accordion--filters .mat-expansion-panel:not(.mat-expanded) .mat-expansion-panel-header:hover:not([aria-disabled=true]) {
         @include u-bg('accent-cool-lighter', !important);
+    }
+
+    .sds-card--list .sds-card__body .mat-accordion .mat-expansion-panel:first-of-type {
+        @include u-border-top(0);
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
     }
 }
 


### PR DESCRIPTION
## Description
Updates css for accordion to have border radius for 1st and last item, but adds exception for accordions inside a card list
Layout component, on destroy, will fire an update filter event resetting the filter value to null
Responsive sidenav modal will auto close if the user resizes their window to be greater than 480 px


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

