### PR TITLE
Fixing selected result alignment issue

### DIFF
--- a/libs/packages/components/src/lib/selected-result/selected-result.component.html
+++ b/libs/packages/components/src/lib/selected-result/selected-result.component.html
@@ -24,7 +24,7 @@
           getObjectValue(result, configuration.primaryTextField)
         " [class.text-base]="disabled" aria-hidden="false" class="sds-tag__close" (click)="removeItem(result)"
         (keyup.enter)="removeItem(result)">
-        <sds-icon [icon]="'x'" size="2x"></sds-icon>
+        <sds-icon [icon]="'x'" size="lg"></sds-icon>
       </button>
     </div>
   </li>


### PR DESCRIPTION
## Description
A couple aligment issues were reported after updating to the latest SDS version. This PR addresses one of them, the other is fixed in sam-styles

## Motivation and Context
A couple aligment issues were reported after updating to the latest SDS version. This PR addresses one of them, the other is fixed in sam-styles

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
Before
<img width="434" alt="Screen Shot 2021-04-07 at 11 47 23 AM" src="https://user-images.githubusercontent.com/72805180/113896229-bf48b080-9797-11eb-85f3-1d92821270ed.png">
After
<img width="434" alt="Screen Shot 2021-04-07 at 11 47 37 AM" src="https://user-images.githubusercontent.com/72805180/113896230-bf48b080-9797-11eb-9894-faf15f009a1b.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

