### PR TITLE
Remove fsd from internal links exception

### DIFF
--- a/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
+++ b/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
@@ -10,10 +10,5 @@
 <a class="usa-link" href="https://USASpending.gov" [hideIcon]="true">USASpending.GOV</a>
 
 
-<h4 class="margin-bottom-2">SDS External Link directive with FSD as internal link </h4>
+<h4 class="margin-bottom-2">FSD considered external link as of @version 10.0.21 </h4>
 <a class="usa-link" href="https://fsd.gov/test">FSD.GOV</a>
-
-
-
-<h4 class="margin-bottom-2">SDS External Link directive with FSD as internal link and open in new tab </h4>
-<a class="usa-link" target="_blank" href="https://fsd.gov/test">FSD.GOV</a>

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -25,7 +25,11 @@ export class ExternalLinkDirective implements OnChanges {
   @Input() target: string;
 
   @Input() public hideIcon: boolean = false;
-  private internalLinks = ['fsd.gov'];
+
+  /** Treat these domains as internal links */
+  private internalLinks = [
+    /** 'fsd.gov' - Removed until fsd.gov contains proper route back to sam.gov */
+  ];
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: string,


### PR DESCRIPTION
## Description
This was requested by Christy during sync up meeting with Cotton Candy and Atomic Tangerine. Until fsd.gov supports links to navigate the user back to beta.sam, it will be considered an external link.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

