### PR TITLE
Set page default to true when retreiving history from url

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.spec.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.spec.ts
@@ -70,6 +70,8 @@ describe('SearchListLayoutComponent', () => {
       totalPages: 0,
       default: true,
     };
+    fixture.detectChanges();
+
     component.updateFilter(filterData);
     fixture.detectChanges();
     tick(100);

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -168,6 +168,8 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
     );
     const params: any = this.getUrlParams(queryString);
     const paramModel: any = this.convertToModel(params);
+
+    this.page.default = true;
     this.page.pageNumber = paramModel['page'] ? +paramModel['page'] : 1;
 
     this.sortField = paramModel['sort'];


### PR DESCRIPTION
## Description
We reset page number to 1 anytime filter update occurs - when clicking browser back button, we don't know for sure what values would be different, so we assume a filter change also occurs, and therefore, were resetting page number to 1 on back button click. Updated to let layout know not to reset page whenever we retrieve history from url

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

