### PR TITLE
Delay loading of video source when preload is none

### DIFF
--- a/libs/packages/components/src/lib/video-player/video-player.component.html
+++ b/libs/packages/components/src/lib/video-player/video-player.component.html
@@ -6,9 +6,9 @@
         [attr.aria-label]="VPConfiguration.description"
       >
         <!-- if Safari/Chrome-->
-          <source src="{{VPConfiguration.sourceMp4}}" type="video/mp4" />
+          <source *ngIf="loadVideoSource" src="{{VPConfiguration.sourceMp4}}" type="video/mp4" />
           <!-- If Firefox/Opera/Chrome/IE -->
-          <source src="{{VPConfiguration.sourceWebm}}" type="video/webm" />
+          <source *ngIf="loadVideoSource"  src="{{VPConfiguration.sourceWebm}}" type="video/webm" />
           <track kind="subtitles" kind="captions" label="English captions" src="{{VPConfiguration.caption}}" srclang="en" default />
       </video>
   </div>

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -82,15 +82,15 @@ export class SdsVideoPlayerComponent implements AfterContentInit, AfterViewInit,
    */
   private _loadVideoSourceOnDemand() {
     const playButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-play');
-    const rewindButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-rewind');
+    const restartButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-restart');
 
-    if (!playButton || !rewindButton) {
+    if (!playButton || !restartButton) {
       // Edge case - if the button to toggle video source does not exist in dom, then add in the
       // video source and let the browser decide when to fetch video data
       this.loadVideoSource = true;
     } else {
       playButton.onclick = () => this.loadVideoSource = true;
-      rewindButton.onclick = () => this.loadVideoSource = true;
+      restartButton.onclick = () => this.loadVideoSource = true;
     }
   }
 

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation, Renderer2, OnChanges, AfterContentInit } from '@angular/core';
+import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation, Renderer2, OnChanges, AfterContentInit, OnInit } from '@angular/core';
 import { GLOBAL_STRINGS } from 'accessible-html5-video-player/js/strings.js';
 import * as InitPxVideo from 'accessible-html5-video-player/js/px-video.js';
 import { VPInterface } from './video-player';
@@ -23,7 +23,7 @@ declare class InitPxVideo {
   styleUrls: ['./css/px-video.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class SdsVideoPlayerComponent implements AfterContentInit, AfterViewInit, OnChanges {
+export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit {
   @Input() VPConfiguration: VPInterface;
   @ViewChild('video') video: ElementRef;
   private config: InitPxVideoConfig;
@@ -37,7 +37,14 @@ export class SdsVideoPlayerComponent implements AfterContentInit, AfterViewInit,
     private renderer2: Renderer2,
   ) {}
 
+  ngOnInit() {
+    if (this.VPConfiguration.preload != 'none') {
+      this.loadVideoSource = true;
+    }
+  }
+  
   ngAfterViewInit() {
+
     if (this.crossorigin) {
       const id = this.elementRef.nativeElement.querySelector('#videoPlayer');
       id.setAttribute('crossorigin', this.crossorigin);
@@ -56,13 +63,9 @@ export class SdsVideoPlayerComponent implements AfterContentInit, AfterViewInit,
     const progressElement: HTMLProgressElement= this.elementRef.nativeElement.querySelector('progress');
 
     this.renderer2.setAttribute(progressElement, 'aria-label', this.VPConfiguration.description + ' progress bar');
-  }
 
-  ngAfterContentInit() {
     if (this.VPConfiguration.preload === 'none') {
       this._loadVideoSourceOnDemand();
-    } else {
-      this.loadVideoSource = true;
     }
   }
 

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -78,7 +78,7 @@ export class SdsVideoPlayerComponent implements AfterContentInit, AfterViewInit,
   /**
    * IE and Edge ignore preload attribute and load video data eagerly. In order to
    * workaround those such browsers, we add video source only after user clicks
-   * on play or rewind button of the video.
+   * on play or restart button of the video.
    */
   private _loadVideoSourceOnDemand() {
     const playButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-play');


### PR DESCRIPTION
## Description
This issue was mainly noticed in IE and Edge. Video elements have a preload attribute that hint to the browser when they'd want to fetch data for the video. We generally prefer to wait until the user has interacted with the video (pressed play) and then fetch the data rather than eagerly fetch and waste potential network data. The issue is that browsers can choose to ignore this attribute and eagerly fetch anyways even when suggested not to. Therefore, we do not include the video source in the DOM until the user demands for it, causing browsers that do pre-fetch to also wait until a source is available in the DOM.


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11 (The video from sam-static-content in our demo does not play in IE - with or without the changes in this PR, but the one from amazon bucket in alpha's home page did in both cases)
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

