### PR TITLE
Search layout display loading on search

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
@@ -25,20 +25,22 @@
 </div>
 <div class="grid-row">
   <div class="grid-col-12">
-    <sds-search-result-list [model]="items" [customResultsTemplate]="customResultsTemplate"
-      [isDefaultModel]="isDefaultModel">
-      <ng-container>
-        <ng-template #resultContent let-item>
-          <div *ngIf="loading">
-            <ng-container *ngTemplateOutlet="loadingScreen"></ng-container>
-          </div>
-          <div *ngIf="!loading">
-            <ng-container *ngTemplateOutlet=" resultContentTemplate, context: { $implicit: item }">
-            </ng-container>
-          </div>
-        </ng-template>
-      </ng-container>
-    </sds-search-result-list>
+    <div *ngIf="!loading; else loadingScreen">
+      <sds-search-result-list [model]="items" [customResultsTemplate]="customResultsTemplate"
+        [isDefaultModel]="isDefaultModel">
+        <ng-container>
+          <ng-template #resultContent let-item>
+            <div *ngIf="loading">
+              <ng-container *ngTemplateOutlet="loadingScreen"></ng-container>
+            </div>
+            <div *ngIf="!loading">
+              <ng-container *ngTemplateOutlet=" resultContentTemplate, context: { $implicit: item }">
+              </ng-container>
+            </div>
+          </ng-template>
+        </ng-container>
+      </sds-search-result-list>
+    </div>
     <sds-pagination *ngIf="!loading && items?.length" [paginationConfiguration]="bottom" [(page)]="page"
       (pageChange)="paginationChange.next($event)">
     </sds-pagination>

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
@@ -30,13 +30,8 @@
         [isDefaultModel]="isDefaultModel">
         <ng-container>
           <ng-template #resultContent let-item>
-            <div *ngIf="loading">
-              <ng-container *ngTemplateOutlet="loadingScreen"></ng-container>
-            </div>
-            <div *ngIf="!loading">
-              <ng-container *ngTemplateOutlet=" resultContentTemplate, context: { $implicit: item }">
+              <ng-container *ngTemplateOutlet="resultContentTemplate, context: { $implicit: item }">
               </ng-container>
-            </div>
           </ng-template>
         </ng-container>
       </sds-search-result-list>

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -175,7 +175,10 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
     this.sortField = paramModel['sort'];
     if (this.filterUpdateModelService) {
       if (paramModel && paramModel['sfm']) {
-          this.filterUpdateModelService.updateModel(paramModel['sfm']);
+        if (!this.isDefaultFilter(paramModel['sfm'])) {
+          this.loading = true;
+        }
+        this.filterUpdateModelService.updateModel(paramModel['sfm']);
       } else {
         this.filterUpdateModelService.updateModel(
           this.configuration.defaultFilterValue
@@ -203,6 +206,7 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
     const cleanModel = this.flatten(filter);
     const op = this.flatten(this.configuration.defaultFilterValue);
     this.isDefaultModel = _.isEqual(cleanModel, op);
+    return this.isDefaultModel;
   }
 
   flatten(input, reference?, output?) {
@@ -344,7 +348,10 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
               result.totalItems / this.page.pageSize
             );
             this.totalItems = result.totalItems;
-          });
+          },
+          (error) => this.loading = false,
+          () => this.loading = false
+          );
       });
     }
   }

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -175,9 +175,6 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
     this.sortField = paramModel['sort'];
     if (this.filterUpdateModelService) {
       if (paramModel && paramModel['sfm']) {
-        if (!this.isDefaultFilter(paramModel['sfm'])) {
-          this.loading = true;
-        }
         this.filterUpdateModelService.updateModel(paramModel['sfm']);
       } else {
         this.filterUpdateModelService.updateModel(
@@ -206,7 +203,6 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
     const cleanModel = this.flatten(filter);
     const op = this.flatten(this.configuration.defaultFilterValue);
     this.isDefaultModel = _.isEqual(cleanModel, op);
-    return this.isDefaultModel;
   }
 
   flatten(input, reference?, output?) {
@@ -348,10 +344,7 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
               result.totalItems / this.page.pageSize
             );
             this.totalItems = result.totalItems;
-          },
-          (error) => this.loading = false,
-          () => this.loading = false
-          );
+          });
       });
     }
   }

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -329,8 +329,9 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
       this.enableApiCall &&
       !this.isDefaultModel
     ) {
+      this.loading = true;
+
       setTimeout(() => {
-        this.loading = true;
         this.service
           .getData({
             page: this.page,
@@ -344,7 +345,10 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
               result.totalItems / this.page.pageSize
             );
             this.totalItems = result.totalItems;
-          });
+          },
+          (error) => this.loading = false,
+          () => this.loading = false
+          );
       });
     }
   }


### PR DESCRIPTION
## Description
Updates logic in layout to display loading regardless of results are initially available or not. Also moves the loading state outside set timeout in order to avoid any flickers in UI between different displays (No Matches vs loading)

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

