### PR TITLE
Video player mobile issue

### DIFF
--- a/libs/packages/components/src/lib/video-player/video-player.component.html
+++ b/libs/packages/components/src/lib/video-player/video-player.component.html
@@ -1,4 +1,4 @@
-<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" >
+<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" (click)="_loadVideo()">
   <div class="px-video-img-captions-container" >
       <div class="px-video-captions hide" aria-hidden="true"></div>
       <video id="videoPlayer" [style.width]="VPConfiguration.width" [style.height]="VPConfiguration.height"

--- a/libs/packages/components/src/lib/video-player/video-player.component.html
+++ b/libs/packages/components/src/lib/video-player/video-player.component.html
@@ -1,4 +1,4 @@
-<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" (click)="onVideoContainerClicked()">
+<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width">
   <div class="px-video-img-captions-container" >
       <div class="px-video-captions hide" aria-hidden="true"></div>
       <video id="videoPlayer" [style.width]="VPConfiguration.width" [style.height]="VPConfiguration.height"

--- a/libs/packages/components/src/lib/video-player/video-player.component.html
+++ b/libs/packages/components/src/lib/video-player/video-player.component.html
@@ -1,4 +1,4 @@
-<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" (click)="_loadVideo()">
+<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" (click)="onVideoContainerClicked()">
   <div class="px-video-img-captions-container" >
       <div class="px-video-captions hide" aria-hidden="true"></div>
       <video id="videoPlayer" [style.width]="VPConfiguration.width" [style.height]="VPConfiguration.height"

--- a/libs/packages/components/src/lib/video-player/video-player.component.html
+++ b/libs/packages/components/src/lib/video-player/video-player.component.html
@@ -1,4 +1,4 @@
-<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width">
+<div #video class="px-video-container" id="{{VPConfiguration.id}}" [style.width]="VPConfiguration.width" >
   <div class="px-video-img-captions-container" >
       <div class="px-video-captions hide" aria-hidden="true"></div>
       <video id="videoPlayer" [style.width]="VPConfiguration.width" [style.height]="VPConfiguration.height"

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -57,12 +57,13 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
       debug: this.VPConfiguration.debug
     }
 
-    const video = new InitPxVideo(this.config);
+    new InitPxVideo(this.config);
     this.video.nativeElement.setAttribute("style", "width:"+this.VPConfiguration.width+";");
 
     const progressElement: HTMLProgressElement= this.elementRef.nativeElement.querySelector('progress');
-
-    this.renderer2.setAttribute(progressElement, 'aria-label', this.VPConfiguration.description + ' progress bar');
+    if (progressElement) {
+      this.renderer2.setAttribute(progressElement, 'aria-label', this.VPConfiguration.description + ' progress bar');
+    }
 
     if (this.VPConfiguration.preload === 'none') {
       this._loadVideoSourceOnDemand();

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -79,15 +79,6 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
     }
   }
 
-  onVideoContainerClicked() {
-    if (this.loadVideoSource) {
-      return;
-    }
-    const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector('#videoPlayer');
-    this.loadVideoSource = true;
-    video.load();
-  }
-
   /**
    * IE and Edge ignore preload attribute and load video data eagerly. In order to
    * workaround those such browsers, we add video source only after user clicks

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -1,5 +1,4 @@
-import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation, Renderer2, OnChanges, AfterContentInit, OnInit, ChangeDetectorRef } from '@angular/core';
-import { GLOBAL_STRINGS } from 'accessible-html5-video-player/js/strings.js';
+import { Component,ViewChild, Input,ElementRef, AfterViewInit, ViewEncapsulation, Renderer2, OnChanges, OnInit, ChangeDetectorRef } from '@angular/core';
 import * as InitPxVideo from 'accessible-html5-video-player/js/px-video.js';
 import { VPInterface } from './video-player';
 
@@ -79,22 +78,13 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
     }
   }
 
-  _loadVideo() {
+  onVideoContainerClicked() {
     if (this.loadVideoSource) {
       return;
     }
-
     const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector('#videoPlayer');
-
     this.loadVideoSource = true;
-    
-    // Due to event handler timing issues in safari, the browser does not load the source
-    // when play and source are set at the same time. So we first set the source, wait for
-    // an event loop, pause, then play the video to trigger source loading
-    setTimeout(() => {
-      video.pause();
-      video.play();
-    });
+    video.load();
   }
 
   /**
@@ -105,14 +95,31 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
   private _loadVideoSourceOnDemand() {
     const playButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-play');
     const restartButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-restart');
+    const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector('#videoPlayer');
+
+    const loadVideo = ($event) => {
+      if (this.loadVideoSource) {
+        return;
+      }
+
+      this.loadVideoSource = true;
+      
+      // Due to event handler timing issues in safari, the browser does not load the source
+      // when play and source are set at the same time. So we first set the source, wait for
+      // an event loop, pause, then play the video to trigger source loading
+      setTimeout(() => {
+        video.pause();
+        video.play();
+      });
+    }
 
     if (!playButton || !restartButton) {
       // Edge case - if the button to toggle video source does not exist in dom, then add in the
       // video source and let the browser decide when to fetch video data
       this.loadVideoSource = true;
     } else {
-      playButton.onclick = this._loadVideo;
-      restartButton.onclick = this._loadVideo;
+      playButton.onclick = loadVideo;
+      restartButton.onclick = loadVideo;
     }
   }
 }

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -79,6 +79,24 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
     }
   }
 
+  _loadVideo() {
+    if (this.loadVideoSource) {
+      return;
+    }
+
+    const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector('#videoPlayer');
+
+    this.loadVideoSource = true;
+    
+    // Due to event handler timing issues in safari, the browser does not load the source
+    // when play and source are set at the same time. So we first set the source, wait for
+    // an event loop, pause, then play the video to trigger source loading
+    setTimeout(() => {
+      video.pause();
+      video.play();
+    });
+  }
+
   /**
    * IE and Edge ignore preload attribute and load video data eagerly. In order to
    * workaround those such browsers, we add video source only after user clicks
@@ -87,31 +105,14 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
   private _loadVideoSourceOnDemand() {
     const playButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-play');
     const restartButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-restart');
-    const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector('#videoPlayer');
-
-    const loadVideo = ($event) => {
-      if (this.loadVideoSource) {
-        return;
-      }
-
-      this.loadVideoSource = true;
-      
-      // Due to event handler timing issues in safari, the browser does not load the source
-      // when play and source are set at the same time. So we first set the source, wait for
-      // an event loop, pause, then play the video to trigger source loading
-      setTimeout(() => {
-        video.pause();
-        video.play();
-      });
-    }
 
     if (!playButton || !restartButton) {
       // Edge case - if the button to toggle video source does not exist in dom, then add in the
       // video source and let the browser decide when to fetch video data
       this.loadVideoSource = true;
     } else {
-      playButton.onclick = loadVideo;
-      restartButton.onclick = loadVideo;
+      playButton.onclick = this._loadVideo;
+      restartButton.onclick = this._loadVideo;
     }
   }
 }


### PR DESCRIPTION
## Description
On mobile, in chrome, video players do not render the controls the same way, so the progress bar html query was returning null and throwing an error in the following aria label attribute addition. Which then prevented the remaining code to add video source from executing. Update to add check so that progress bar is only modified if the query is able to find it in the html

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

