### PR TITLE
Treat empty filters as default, consistently use boolean for checkboxes

### DIFF
--- a/libs/documentation/src/lib/pages/layout/layout.component.html
+++ b/libs/documentation/src/lib/pages/layout/layout.component.html
@@ -23,7 +23,7 @@
             <sds-accordion-title>Filter By</sds-accordion-title>
             <sds-accordion-content>
 
-              <sds-filters [options]="options" [advancedFilters]="true" [sortMoreFilterBy]="'label'"
+              <sds-filters [options]="options" [advancedFilters]="true" [sortMoreFilterBy]="'label'" [getCleanModel]="true"
                 [isHistoryEnable]="false" [form]="form" [fields]="fields" [model]="filterModel"
                 [defaultModel]="listConfig.defaultFilterValue"
                 (filterChange)="filterChange$.next($event)"></sds-filters>

--- a/libs/documentation/src/lib/pages/layout/layout.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout.component.ts
@@ -27,7 +27,7 @@ export class ResultsLayoutComponent implements AfterViewInit, OnInit {
       { text: 'Entity Name', value: 'legalBusinessName' },
       { text: 'Status', value: 'registrationStatus' },
     ],
-    defaultFilterValue: { status: { registrationStatus: { Active: 'true', Inactive: 'false' } } },
+    defaultFilterValue: { status: { registrationStatus: { Active: true, Inactive: false } } },
   };
 
   /* Sort config change demo */

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -62,7 +62,11 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
 
   @Input() enableApiCall: boolean = true;
 
+  /**
+   * Set to true when either filter is empty or filter is equal to default model
+   */
   isDefaultModel: boolean = true;
+
   /**
    * Filter information
    */
@@ -201,6 +205,13 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
 
   isDefaultFilter(filter) {
     const cleanModel = this.flatten(filter);
+    
+    // No filter values set
+    if (Object.keys(cleanModel).length === 0) {
+      this.isDefaultModel = true;
+      return;
+    }
+
     const op = this.flatten(this.configuration.defaultFilterValue);
     this.isDefaultModel = _.isEqual(cleanModel, op);
   }
@@ -294,8 +305,23 @@ export class SearchListLayoutComponent implements OnChanges, OnInit {
       encode: false,
       filter: this.longFormatDate,
     });
-    obj = qs.parse(encodedValues);
+    obj = qs.parse(encodedValues, {decoder: this.convertToModelParser});
     return obj;
+  }
+
+  /**
+   * Decoder for qs.parse to convert true / false strings to boolean values
+   */
+  convertToModelParser(str: string, decoder: qs.defaultDecoder, charset: string, type: 'key' | 'value') {
+    if (type === 'key') {
+      return decoder(str, decoder, charset);
+    }
+
+    if (str === 'true' || str === 'false') {
+      return str === 'true' ? true : false;
+    }
+
+    return decoder(str, decoder, charset);
   }
 
   longFormatDate(prefix, value) {

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -274,8 +274,24 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
       encode: false,
       filter: this.longFormatDate,
     });
-    obj = qs.parse(encodedValues);
+    obj = qs.parse(encodedValues, {decoder: this.cleanModelParser});
     return obj;
+  }
+
+  /**
+   * Parser for qs.parse - if input string is true / false, 
+   * convert to boolean value, otherwise use default decoder
+   */
+  cleanModelParser(str: string, decoder: qs.defaultDecoder, charset: string, type: 'key' | 'value') {
+    if (type === 'key') {
+      return decoder(str, decoder, charset);
+    }
+
+    if (str === 'true' || str === 'false') {
+      return str === 'true' ? true : false;
+    }
+
+    return decoder(str, decoder, charset);
   }
 
   longFormatDate(prefix, value) {


### PR DESCRIPTION
## Description
Empty filter values should also be considered as default and display instructions to users to Select Criteria
Changes to checkbox / multi-checkbox should consistently use boolean values when checked / unchecked - currently the conversion to clean model was changing them to strings

## Motivation and Context
#704 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

