### PR TITLE
Git 688 external link directive update

### DIFF
--- a/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
+++ b/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
@@ -12,3 +12,9 @@
 
 <h4 class="margin-bottom-2">FSD considered external link as of @version 10.0.21 </h4>
 <a class="usa-link" href="https://fsd.gov/test">FSD.GOV</a>
+
+<h4 class="margin-bottom-2">Aria label attached to link, but does not indicate link will open in new window</h4>
+<a class="usa-link" href="https://Acquisition.gov" aria-label="Acquisition Website Link">Acquisition.gov</a>
+
+<h4 class="margin-bottom-2">Aria label attached to link and contains new window keyword</h4>
+<a class="usa-link" href="https://Acquisition.gov" aria-label="Open Acquisition.gov site in a new window">Acquisition.gov</a>

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -10,7 +10,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
     <a id="test" href="google.com">Google </a>
     <a id="test2" [hideIcon]="true" href="google.com" aria-label="test aria label - opens in a new window">Google </a>
     <a id="test3">Not Google </a>
-    <a id="test4" href="{{name}}/settings/test123">Google </a>
+    <a id="test4" href="{{name}}/settings/test123" aria-label="Test label">Google </a>
     <a id="test5" [hideIcon]="true" href="google.com" aria-label="test aria label with no keywords">Google </a>
     <a id="test6" [hideIcon]="true" href="google.com">Google <span>test element</span></a>
   `
@@ -65,9 +65,9 @@ describe('Sam External Link Directive', () => {
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('test aria label - opens in a new window');
   });
 
-  it('Should not add aria label to internal links', () => {
+  it('Should not update aria label to internal links', () => {
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test4'));
-    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('');
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Test label');
   });
 
   it('Should update aria label to external link if existing aria label does not indicate opening in new window', () => {

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -8,9 +8,11 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 @Component({
   template: `
     <a id="test" href="google.com">Google </a>
-    <a id="test2" [hideIcon]="true" href="google.com" aria-label="test aria label">Google </a>
+    <a id="test2" [hideIcon]="true" href="google.com" aria-label="test aria label - opens in a new window">Google </a>
     <a id="test3">Not Google </a>
     <a id="test4" href="{{name}}/settings/test123">Google </a>
+    <a id="test5" [hideIcon]="true" href="google.com" aria-label="test aria label with no keywords">Google </a>
+    <a id="test6" [hideIcon]="true" href="google.com">Google <span>test element</span></a>
   `
 })
 class TestComponent {
@@ -54,21 +56,33 @@ describe('Sam External Link Directive', () => {
     expect(icons.length).toEqual(1);
   });
 
-  it ('Showd add aria label attribute to external links if one does not exist', () => {
+  it ('Should add aria label attribute to external links using inner text if one does not exist', () => {
     fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test'));
-    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open google.com in a new window');
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open Google in a new window');
   });
 
-  it('Should not add aria label to external link if one is already provided', () => {
+  it('Should not update aria label to external link if valid aria label is set', () => {
     fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test2'));
-    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('test aria label');
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('test aria label - opens in a new window');
   });
 
   it('Should not add aria label to internal links', () => {
     fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test4'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('');
-  })
+  });
+
+  it('Should update aria label to external link if existing aria label does not indicate opening in new window', () => {
+    fixture.detectChanges();
+    const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test5'));
+    expect(testElementWithoutAriaLabel.nativeNode['ariaLabel']).toEqual('test aria label with no keywords - opens in a new window');
+  });
+
+  it ('Should add aria label attribute to external links using href if one does not exist', () => {
+    fixture.detectChanges();
+    const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test6'));
+    expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open google.com in a new window');
+  });
 });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -38,6 +38,7 @@ describe('Sam External Link Directive', () => {
 
     fixture = TestBed.createComponent(TestComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it('should create component', () => {
@@ -45,43 +46,36 @@ describe('Sam External Link Directive', () => {
   });
 
   it('should create one icon', () => {
-    fixture.detectChanges();
     const icons = findIcons();
     expect(icons.length).toEqual(1);
   });
 
   it('should not create an icon', () => {
-    fixture.detectChanges();
     const icons = findIcons();
     expect(icons.length).toEqual(1);
   });
 
   it ('Should add aria label attribute to external links using inner text if one does not exist', () => {
-    fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open Google in a new window');
   });
 
   it('Should not update aria label to external link if valid aria label is set', () => {
-    fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test2'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('test aria label - opens in a new window');
   });
 
   it('Should not add aria label to internal links', () => {
-    fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test4'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('');
   });
 
   it('Should update aria label to external link if existing aria label does not indicate opening in new window', () => {
-    fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test5'));
-    expect(testElementWithoutAriaLabel.nativeNode['ariaLabel']).toEqual('test aria label with no keywords - opens in a new window');
+    expect(testElementWithoutAriaLabel.nativeElement.getAttribute('aria-label')).toEqual('test aria label with no keywords - opens in a new window');
   });
 
   it ('Should add aria label attribute to external links using href if one does not exist', () => {
-    fixture.detectChanges();
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test6'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open google.com in a new window');
   });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -19,7 +19,6 @@ export class ExternalLinkDirective implements OnChanges {
   @HostBinding('attr.rel') relAttr = '';
   @HostBinding('attr.target') targetAttr = '';
   @HostBinding('attr.href') hrefAttr = '';
-  @HostBinding('attr.aria-label') ariaLabel = '';
 
   @Input() href: string;
   @Input() target: string;
@@ -48,8 +47,8 @@ export class ExternalLinkDirective implements OnChanges {
     this.relAttr = 'noopener';
     this.targetAttr = '_blank';
 
-    this.ariaLabel = this._getAriaLabel();
-    (this.el.nativeElement as HTMLAnchorElement).setAttribute('aria-label', this.ariaLabel);
+    const ariaLabel = this._getAriaLabel();
+    (this.el.nativeElement as HTMLAnchorElement).setAttribute('aria-label', ariaLabel);
 
     if (!this.hideIcon) {
       this.createIcon();

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -35,7 +35,7 @@ export class ExternalLinkDirective implements OnChanges {
     @Inject(PLATFORM_ID) private platformId: string,
     private el: ElementRef,
     private vc: ViewContainerRef
-  ) {}
+  ) { }
 
   public ngOnChanges() {
     this.hrefAttr = this.href;
@@ -43,26 +43,52 @@ export class ExternalLinkDirective implements OnChanges {
 
     if (!this.isExternalLink) {
       return;
-    } else {
-      if (!this.hideIcon) {
-        this.createIcon();
-      }
-      this.relAttr = 'noopener';
-      this.targetAttr = '_blank';
     }
 
-    /**
-     * Add aria label warning users the link will open a new window if the anchor tag
-     * does not already have an aria label
-     */
-    if (this.targetAttr === '_blank') {
-      const currentAriaLabel = this.el.nativeElement.getAttribute('aria-label');
-      if (!currentAriaLabel || currentAriaLabel.length === 0) {
-        this.ariaLabel = `Open ${this.href} in a new window`;
-      } else {
-        this.ariaLabel = currentAriaLabel;
-      }
+    this.relAttr = 'noopener';
+    this.targetAttr = '_blank';
+
+    this.ariaLabel = this._getAriaLabel();
+    (this.el.nativeElement as HTMLAnchorElement).setAttribute('aria-label', this.ariaLabel);
+
+    if (!this.hideIcon) {
+      this.createIcon();
     }
+  }
+
+  /**
+   * Appends indication that the link will open in a separate window to the aria label.
+   * If link does not contain any aria label, then an aria label will be generated using either the inner text
+   *  or href value based on whether the anchor element contains children elements or not
+   * If link contains aria label, but the label does not contain key words 'new' or 'window',
+   *  then the text 'opens in a new window' will be appended to the end of the aria label
+   * If link contains aria label as well as the key words 'new' and 'window', then aria label will
+   *  be kept as is
+   */
+  private _getAriaLabel(): string {
+
+    const anchorElement = this.el.nativeElement as HTMLAnchorElement
+    const currentAriaLabel: string = anchorElement.getAttribute('aria-label');
+
+    /** No aria label, attach a default one using inner text if anchor does not contain additional
+     * html element as children. If anchor does contain additional html element as children, then use href 
+     */
+    if (!currentAriaLabel || currentAriaLabel.length === 0) {
+      let label = anchorElement.firstElementChild ? this.href : anchorElement.innerText;
+      label = label.trim();
+      return `Open ${label} in a new window`;
+    }
+
+    const lowerCaseAriaLabel = currentAriaLabel.toLowerCase();
+
+    /** Aria label already indicates link will open in a new window, set to defined aria label */
+    if (lowerCaseAriaLabel.indexOf('new') != -1 && lowerCaseAriaLabel.indexOf('window') != -1) {
+      return currentAriaLabel;
+    }
+
+    /** Aria label is attached, but does not indicate link will open in new window. 
+       Add opens in new window keyword to aria label */
+    return `${currentAriaLabel} - opens in a new window`;
   }
 
   private get isExternalLink(): boolean {


### PR DESCRIPTION
## Description
Changes to external link directives:
If an aria label is provided for the external link, but label does not contain key words 'new' and 'window', the text '- opens in a new window' will be appended to the aria label
If no aria label is given, then the directive will first attempt to use the innerText. If the anchor tag contains any children nodes (icons, span tags, etc), then the href value will be used instead
If an aria label is provided and the label does indicate the link will open in a new window, then the label will remain as is

## Motivation and Context
#688 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

