### PR TITLE
Allow multi-line strings for radio options

### DIFF
--- a/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.component.html
+++ b/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.component.html
@@ -1,0 +1,17 @@
+<p>
+  You can create radio options with multi-line text by adding description to the radio options. Each option
+  can take a description property - an array of strings - where each string will be displayed in a new line.
+</p>
+<p>
+  Additionally, to show each radio option as a tile, you can enable <code> tile: true </code> in
+  the template options.
+</p>
+<p>
+  You can also declare classes radio labels through <code>optionsClass</code> property. This class will be
+  applied to each label in the radio options
+</p>
+
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form" (modelChange)="onModelChange($event)">
+  </formly-form>
+</form>

--- a/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.component.ts
+++ b/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.component.ts
@@ -1,0 +1,84 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
+
+@Component({
+  selector: 'gsa-sam-radio-advanced',
+  templateUrl: './radio-advanced.component.html',
+})
+export class RadioAdvancedComponent {
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'taxFilingStatus',
+      type: 'radio',
+      templateOptions: {
+        label: 'Tax Filing Structure',
+        tile: true,
+        description:
+          'Select how your business or organization is defined by the IRS.',
+        required: true,
+        optionsClass: `text-secondary-darker text-bold`,
+        options: [
+          {
+            value: 'ccorp',
+            label:
+              'Corporate Entity, Not Tax Exempt (Firm pays U.S. Federal Income Taxes or U.S. Possession Income Taxes)',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States'
+            ]
+          },
+          {
+            value: 'nonprofit',
+            label:
+              'Corporate Entity, Tax Exempt (Firm does not pay U.S. Federal Income Taxes nor U.S. Possession Income Taxes)',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States'
+            ]
+          },
+          {
+            value: 'partnerllc',
+            label: 'Partnership or Limited Liability Partnership',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States',
+            ],
+          },
+          {
+            value: 'soleproprietorship',
+            label: 'Sole Proprietorship',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States'
+            ]
+          },
+          {
+            value: 'international',
+            label: 'International Organization',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States'
+            ]
+          },
+          {
+            value: 'other',
+            label: 'Other',
+            description: [
+              '13240 GREENBURY CIRCUIT SUITE 200',
+              'Sterling, VA 20165 United States'
+            ]
+          },
+        ],
+      },
+    },
+  ];
+
+  onModelChange($event) {
+    console.log($event);
+  }
+}

--- a/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.module.ts
+++ b/libs/documentation/src/lib/components/formly-radio/demos/advanced/radio-advanced.module.ts
@@ -1,0 +1,15 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { SdsFormlyModule } from "@gsa-sam/sam-formly";
+import { FormlyModule } from "@ngx-formly/core";
+import { RadioAdvancedComponent } from "./radio-advanced.component";
+
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
+  declarations: [RadioAdvancedComponent],
+  exports: [RadioAdvancedComponent],
+  bootstrap: [RadioAdvancedComponent]
+})
+export class RadioAdvancedModule {}

--- a/libs/documentation/src/lib/components/formly-radio/radio.module.ts
+++ b/libs/documentation/src/lib/components/formly-radio/radio.module.ts
@@ -8,6 +8,8 @@ import { DocumentationTemplatePage } from '../shared/template-page/template.comp
 import { DocumentationComponentsSharedModule, DocumentationDemoList } from '../shared/index';
 import { ComponentWrapperComponent } from '../../shared/component-wrapper/component-wrapper.component';
 import { RadioBasicModule } from './demos/basic/radio-basic.module';
+import { RadioAdvancedComponent } from './demos/advanced/radio-advanced.component';
+import { RadioAdvancedModule } from './demos/advanced/radio-advanced.module';
 
 declare var require: any;
 const DEMOS = {
@@ -17,6 +19,13 @@ const DEMOS = {
     code: require('!!raw-loader!./demos/basic/radio-basic.component'),
     markup: require('!!raw-loader!./demos/basic/radio-basic.component.html'),
     path: 'libs/documentation/src/lib/components/formly-radio/demos/basic'
+  },
+  advanced: {
+    title: 'Advanced Form Radio',
+    type: RadioAdvancedComponent,
+    code: require('!!raw-loader!./demos/advanced/radio-advanced.component'),
+    markup: require('!!raw-loader!./demos/advanced/radio-advanced.component.html'),
+    path: 'libs/documentation/src/lib/components/formly-radio/demos/advanced'
   }
 };
 
@@ -48,7 +57,8 @@ export const ROUTES = [
   imports: [
     CommonModule,
     DocumentationComponentsSharedModule,
-    RadioBasicModule
+    RadioBasicModule,
+    RadioAdvancedModule,
   ]
 })
 export class RadioModule {

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -1,0 +1,19 @@
+<form class="usa-radio" [id]="id" [attr.aria-label]="to.ariaLabel? to.ariaLabel : to.label"
+  [attr.aria-describedby]="to.description ? id + '_description' : undefined">
+  <ng-container *ngFor="
+    let option of to.options | formlySelectOptions: field | async;
+    let i = index">
+    <input type="radio" [id]="id + '_' + i" class="usa-radio__input"
+      [ngClass]="{'usa-radio__input--tile': to.tile, 'usa-input--error': !showError}" [name]="id" [value]="option.value"
+      [formControl]="formControl" [formlyAttributes]="field" />
+    <label [attr.class]="'usa-radio__label ' + (to.optionsClass ? to.optionsClass : '')" [for]="id + '_' + i">
+      {{ option.label }}
+      <!-- Go through templateoptions' option because formlySelectOptions pipe will include only limited fields -->
+      <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
+        <div class="usa-checkbox__label-description">
+          <span class="display-block" *ngFor="let description of to.options[i].description">{{description}}</span>
+        </div>
+      </ng-container>
+    </label>
+  </ng-container>
+</form>

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -1,31 +1,9 @@
-import { Component } from '@angular/core';
+import { Component} from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 
 @Component({
   selector: 'sds-formly-field-radio',
-  template: `
-    <form class="usa-radio" [id]="id"
-      [attr.aria-label]="to.ariaLabel? to.ariaLabel : to.label" [attr.aria-describedby]="to.description ? id + '_description' : undefined">
-      <ng-container
-        *ngFor="
-          let option of to.options | formlySelectOptions: field | async;
-          let i = index">
-        <input
-          type="radio"
-          [id]="id + '_' + i"
-          class="usa-radio__input"
-          [name]="id"
-          [class.usa-input--error]="showError"
-          [value]="option.value"
-          [formControl]="formControl"
-          [formlyAttributes]="field"
-        />
-        <label class="usa-radio__label" [for]="id + '_' + i">
-          {{ option.label }}
-        </label>
-      </ng-container>
-    </form>
-  `,
+  templateUrl: './radio.html',
 })
 export class FormlyFieldRadioComponent extends FieldType {
   defaultOptions = {


### PR DESCRIPTION
## Description
Update radio formly to allow description array property for each option, where each description will be rendered in a new line underneath the radio's main label. 

## Motivation and Context
IAE-51928

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

