### PR TITLE
IAEDEV-51540: Fix search widths

### DIFF
--- a/libs/documentation/src/lib/components/search/demos/optional/search-optional.component.ts
+++ b/libs/documentation/src/lib/components/search/demos/optional/search-optional.component.ts
@@ -14,11 +14,11 @@ export class SearchOptional {
     id: 'ddSearch',
     placeholder: 'eg: Acme Corporation',
     dropdown: {
-     
+
       id: 'ddSearchOptions',
       options: [
         {value: '-', label: '--Select--'},
-        { value: '1', label: 'One' },
+        { value: '1', label: 'One With Long Text' },
         { value: '2', label: 'Two' },
         { value: '3', label: 'Three' }
       ]
@@ -46,7 +46,7 @@ export class SearchOptional {
     size: 'large',
     dropdown: {
       id: 'bigddSearchOptions',
-     
+
       options: [
         {value: '-', label: '--Select--'},
         { value: '1', label: 'One' },

--- a/libs/packages/components/src/lib/search/search.component.html
+++ b/libs/packages/components/src/lib/search/search.component.html
@@ -1,7 +1,7 @@
 <form class="usa-form usa-search grid-row" [ngClass]="getClass()" role="search">
   <label *ngIf="hasDropdown()" class="usa-sr-only" [attr.for]="searchSettings.dropdown.id">Dropdown label</label>
   <select *ngIf="hasDropdown()" [value]="model.searchCategory? model.searchCategory :''" #selectEl name="search options"
-    aria-label="Search Options" class="usa-select grid-col-12 tablet:grid-col-6" [attr.id]="searchSettings.dropdown.id"
+    aria-label="Search Options" class="usa-select grid-col-12 tablet:grid-col-auto" [attr.id]="searchSettings.dropdown.id"
     (change)="writeValueToModel()">
     <ng-container *ngFor="let item of searchSettings.dropdown.options">
       <optgroup *ngIf="item.group" label="{{item.label}}">
@@ -21,7 +21,7 @@
 <ng-template #inputTemplate>
 
   <div class="position-relative grid-col-12" [ngClass]="{
-  'suffix-icon': searchSettings.isSuffixSearchIcon, 'tablet:grid-col-6': hasDropdown()}">
+  'suffix-icon': searchSettings.isSuffixSearchIcon, 'tablet:grid-col': hasDropdown()}">
     <label class="usa-sr-only" [attr.for]="searchSettings.id">Search</label>
     <input #inputEl [value]="model.searchText? model.searchText :''" [ngClass]="[searchSettings?.inputClass ? searchSettings?.inputClass : '', !hasDropdown() ? 'no-drop' : '']"
       [attr.id]="searchSettings.id" type="search" class="usa-input" name="search"

--- a/libs/packages/components/src/lib/search/search.component.scss
+++ b/libs/packages/components/src/lib/search/search.component.scss
@@ -23,8 +23,8 @@ input::-ms-clear {
     transition: color .2s;
   }
 
-  .searchicon {
-    width: 3rem;
+  .search-icon {
+    // width: 3rem;
     top: 0px;
   }
 

--- a/libs/packages/components/src/lib/search/search.component.scss
+++ b/libs/packages/components/src/lib/search/search.component.scss
@@ -25,10 +25,12 @@ input::-ms-clear {
 
   .searchicon {
     width: 3rem;
+    top: 0px;
   }
 
   .close-icon {
     width: 4rem;
+    top: 4px;
   }
 }
 .no-drop{

--- a/libs/packages/components/src/lib/search/search.component.scss
+++ b/libs/packages/components/src/lib/search/search.component.scss
@@ -24,7 +24,6 @@ input::-ms-clear {
   }
 
   .search-icon {
-    // width: 3rem;
     top: 0px;
   }
 


### PR DESCRIPTION

## Description
Fixes issue where when dropdown is shown, it takes up 50% of the area whereas it used to take up less. This caused issues where placeholder text was not fitting in textarea. Also fixes an issue in IE where suffix icon was not aligned.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-51540

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [x] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

