### PR TITLE
Fix tests with wrong expectation

### DIFF
--- a/libs/packages/components/src/lib/date/sds-date.pipe.spec.ts
+++ b/libs/packages/components/src/lib/date/sds-date.pipe.spec.ts
@@ -12,7 +12,7 @@ fdescribe('SdsDatePipe', () => {
     const todayDate = new Date(today);
     const hours = todayDate.getHours();
     const min = todayDate.getMinutes();
-    expect(pipe.transform(today)).toBe(`${hours > 12 ? hours - 12 : hours}:${min} ${hours > 12 ? 'PM': 'AM'}`);
+    expect(pipe.transform(today)).toBe(`${hours > 12 ? hours - 12 : hours}:${min < 10 ? `0${min}` : min} ${hours > 12 ? 'PM': 'AM'}`);
   });
   it('should display the time when date displayed is today (date string)', () => {
     const pipe = new SdsDatePipe(new DatePipe('en-us'));
@@ -20,7 +20,7 @@ fdescribe('SdsDatePipe', () => {
     const today = todayDate.toISOString()
     const hours = todayDate.getHours();
     const min = todayDate.getMinutes();
-    expect(pipe.transform(today)).toBe(`${hours > 12 ? hours - 12 : hours}:${min} ${hours > 12 ? 'PM': 'AM'}`);
+    expect(pipe.transform(today)).toBe(`${hours > 12 ? hours - 12 : hours}:${min < 10 ? `0${min}` : min} ${hours > 12 ? 'PM': 'AM'}`);
   });
 
   it('should display the date without the year when date displayed is this calendar year (milliseconds)', () => {


### PR DESCRIPTION
## Description
Fixes tests which expected that minutes wouldn't be zero padded when less than 10. This fix pads expected value with '0' if less that 10 to match shortTime

## Motivation and Context
Tests fail when minute value less than 10, this PR fixes those tests


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

