### PR TITLE
Treat mailto links as internal links

### DIFF
--- a/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
+++ b/libs/documentation/src/lib/components/external-link/demos/basic/external-link-basic.component.html
@@ -18,3 +18,6 @@
 
 <h4 class="margin-bottom-2">Aria label attached to link and contains new window keyword</h4>
 <a class="usa-link" href="https://Acquisition.gov" aria-label="Open Acquisition.gov site in a new window">Acquisition.gov</a>
+
+<h4 class="margin-bottom-2">Email Link</h4>
+<a class="usa-link" href="mailto:IAEOutreach@gsa.gov" aria-label="Mail To IAEOutreach@gsa.gov">IAEOutreach@gsa.gov</a>

--- a/libs/packages/components/src/lib/date/sds-date.pipe.spec.ts
+++ b/libs/packages/components/src/lib/date/sds-date.pipe.spec.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { SdsDatePipe } from './sds-date.pipe';
 
-fdescribe('SdsDatePipe', () => {
+describe('SdsDatePipe', () => {
   it('create an instance', () => {
     const pipe = new SdsDatePipe(new DatePipe('en-us'));
     expect(pipe).toBeTruthy();

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -85,7 +85,6 @@ describe('Sam External Link Directive', () => {
     const mailToLink = fixture.debugElement.query(By.css('#test7'));
     const externalLinkIcon = mailToLink.nativeElement.querySelector('usa-link--external');
     expect(externalLinkIcon).toBeNull();
-    console.log(mailToLink);
     expect(mailToLink.children.length).toEqual(0);
   });
 });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.spec.ts
@@ -13,6 +13,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
     <a id="test4" href="{{name}}/settings/test123" aria-label="Test label">Google </a>
     <a id="test5" [hideIcon]="true" href="google.com" aria-label="test aria label with no keywords">Google </a>
     <a id="test6" [hideIcon]="true" href="google.com">Google <span>test element</span></a>
+    <a id="test7" href="mailto:google.com">Email Google</a>
   `
 })
 class TestComponent {
@@ -78,5 +79,13 @@ describe('Sam External Link Directive', () => {
   it ('Should add aria label attribute to external links using href if one does not exist', () => {
     const testElementWithoutAriaLabel = fixture.debugElement.query(By.css('#test6'));
     expect(testElementWithoutAriaLabel.attributes['aria-label']).toEqual('Open google.com in a new window');
+  });
+
+  it ('Should treat links that start with mailto as internal links', () => {
+    const mailToLink = fixture.debugElement.query(By.css('#test7'));
+    const externalLinkIcon = mailToLink.nativeElement.querySelector('usa-link--external');
+    expect(externalLinkIcon).toBeNull();
+    console.log(mailToLink);
+    expect(mailToLink.children.length).toEqual(0);
   });
 });

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -113,6 +113,4 @@ export class ExternalLinkDirective implements OnChanges {
     spanElement.classList.add('font-body-md');
     this.el.nativeElement.appendChild(spanElement);
   }
-
-
 }

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -30,6 +30,8 @@ export class ExternalLinkDirective implements OnChanges {
     /** 'fsd.gov' - Removed until fsd.gov contains proper route back to sam.gov */
   ];
 
+  private readonly emailLinkKeyword = 'mailto';
+
   constructor(
     @Inject(PLATFORM_ID) private platformId: string,
     private el: ElementRef,
@@ -98,6 +100,7 @@ export class ExternalLinkDirective implements OnChanges {
     return (
       isPlatformBrowser(this.platformId) &&
       !link.includes(location.hostname) &&
+      link.indexOf(this.emailLinkKeyword) !== 0  &&
       !this.internalLinks.includes(link)
     );
   }
@@ -110,4 +113,6 @@ export class ExternalLinkDirective implements OnChanges {
     spanElement.classList.add('font-body-md');
     this.el.nativeElement.appendChild(spanElement);
   }
+
+
 }


### PR DESCRIPTION
## Description
Anchor tags with href that start with the word 'mailto' will not be modified by the external link directive

## Motivation and Context
#728 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

