### PR TITLE
Display label tags in readonly mode

### DIFF
--- a/libs/documentation/src/lib/components/formly-readonly/demos/basic/readonly-basic.component.ts
+++ b/libs/documentation/src/lib/components/formly-readonly/demos/basic/readonly-basic.component.ts
@@ -46,6 +46,7 @@ export class ReadonlyBasicComponent implements OnInit {
       defaultValue: 'Jane',
       templateOptions: {
         label: 'Input Type',
+        tagText: 'Tag',
         description: 'Enter text',
         hideOptional: true,
       },
@@ -78,6 +79,8 @@ export class ReadonlyBasicComponent implements OnInit {
       templateOptions: {
         label: 'Textarea Type',
         description: 'Enter text',
+        tagText: 'Purple Tag',
+        tagClass: 'sds-tag--info-purple',
         hideOptional: true,
         rows: 6,
       },

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.html
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-container.component.html
@@ -1,13 +1,24 @@
 <span [ngSwitch]="formlyType">
-  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.INPUT" [label]="label" [value]="value"></sds-readonly-input>
-  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.TEXTAREA" [label]="label" [value]="value"></sds-readonly-input>
-  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.READONLY" [label]="label" [value]="value"></sds-readonly-input>
-  <sds-readonly-datepicker *ngSwitchCase="sdsFormlyTypes.DATEPICKER" [label]="label" [value]="value"></sds-readonly-datepicker>
-  <sds-readonly-select *ngSwitchCase="sdsFormlyTypes.SELECT" [label]="label" [value]="value" [selectOptions]="additionalConfig.providedOptions"></sds-readonly-select>
-  <sds-readonly-radio *ngSwitchCase="sdsFormlyTypes.RADIO" [label]="label" [value]="value" [radioOptions]="additionalConfig.providedOptions"></sds-readonly-radio>
-  <sds-readonly-fileinfo *ngSwitchCase="sdsFormlyTypes.FILEINFO" [label]="label" [value]="value" [fileInfoOptions]="additionalConfig.providedOptions"></sds-readonly-fileinfo>
-  <sds-readonly-autocomplete *ngSwitchCase="sdsFormlyTypes.AUTOCOMPLETE" [label]="label" [value]="value" [autocompleteSettings]="additionalConfig.autocompleteOptions"></sds-readonly-autocomplete>
-  <sds-readonly-checkbox *ngSwitchCase="sdsFormlyTypes.CHECKBOX" [label]="label" [value]="value"></sds-readonly-checkbox>
-  <sds-readonly-multicheckbox *ngSwitchCase="sdsFormlyTypes.MULTICHECKBOX" [label]="label" [value]="value" [multicheckboxOptions]="additionalConfig.providedOptions"></sds-readonly-multicheckbox>
-  <sds-readonly-daterange *ngSwitchCase="sdsFormlyTypes.DATERANGEPICKER" [label]="label" [value]="value" [daterangepickerOptions]="additionalConfig.daterangepickerOptions"></sds-readonly-daterange>
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.INPUT" [label]="label" [value]="value" 
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-input>
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.TEXTAREA" [label]="label" [value]="value"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-input>
+  <sds-readonly-input *ngSwitchCase="sdsFormlyTypes.READONLY" [label]="label" [value]="value"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-input>
+  <sds-readonly-datepicker *ngSwitchCase="sdsFormlyTypes.DATEPICKER" [label]="label" [value]="value"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-datepicker>
+  <sds-readonly-select *ngSwitchCase="sdsFormlyTypes.SELECT" [label]="label" [value]="value" [selectOptions]="additionalConfig.providedOptions"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-select>
+  <sds-readonly-radio *ngSwitchCase="sdsFormlyTypes.RADIO" [label]="label" [value]="value" [radioOptions]="additionalConfig.providedOptions"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-radio>
+  <sds-readonly-fileinfo *ngSwitchCase="sdsFormlyTypes.FILEINFO" [label]="label" [value]="value" [fileInfoOptions]="additionalConfig.providedOptions"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-fileinfo>
+  <sds-readonly-autocomplete *ngSwitchCase="sdsFormlyTypes.AUTOCOMPLETE" [label]="label" [value]="value" 
+    [autocompleteSettings]="additionalConfig.autocompleteOptions" [to]="formlyFieldConfig?.templateOptions"></sds-readonly-autocomplete>
+  <sds-readonly-checkbox *ngSwitchCase="sdsFormlyTypes.CHECKBOX" [label]="label" [value]="value"
+    [to]="formlyFieldConfig?.templateOptions"></sds-readonly-checkbox>
+  <sds-readonly-multicheckbox *ngSwitchCase="sdsFormlyTypes.MULTICHECKBOX" [label]="label" [value]="value" 
+    [multicheckboxOptions]="additionalConfig.providedOptions" [to]="formlyFieldConfig?.templateOptions"></sds-readonly-multicheckbox>
+  <sds-readonly-daterange *ngSwitchCase="sdsFormlyTypes.DATERANGEPICKER" [label]="label" [value]="value" 
+    [daterangepickerOptions]="additionalConfig.daterangepickerOptions" [to]="formlyFieldConfig?.templateOptions"></sds-readonly-daterange>
 </span> 

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-autocomplete.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-autocomplete.ts
@@ -4,12 +4,20 @@ import { SDSAutocompletelConfiguration } from '@gsa-sam/components';
 @Component({
   selector: `sds-readonly-autocomplete`,
   template: `    
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span class="text-bold" [innerHTML]="displayValue"></span>
   `
 })
 export class ReadonlyAutocompleteComponent implements OnInit {
 
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() autocompleteSettings: SDSAutocompletelConfiguration;

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-autocomplete.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-autocomplete.ts
@@ -6,7 +6,7 @@ import { SDSAutocompletelConfiguration } from '@gsa-sam/components';
   template: `    
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-checkbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-checkbox.ts
@@ -4,11 +4,19 @@ import { Component, Input } from "@angular/core";
 @Component({
   selector: `sds-readonly-checkbox`,
   template: `
-      <label class="usa-label">{{label}}</label>
-      <span class="text-bold">{{value ? 'Checked' : 'Unchecked'}}</span>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
+    <span class="text-bold">{{value ? 'Checked' : 'Unchecked'}}</span>
   `
 })
 export class ReadonlyCheckboxComponent {
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
 }

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-checkbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-checkbox.ts
@@ -6,7 +6,7 @@ import { Component, Input } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-datepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-datepicker.ts
@@ -4,12 +4,19 @@ import { Component, Input } from "@angular/core";
 @Component({
   selector: 'sds-readonly-datepicker',
   template: `
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span class="text-bold"> {{value ? (value | date: 'mediumDate') : '&mdash;'}}</span>
   `,
 })
 export class ReadonlyDatepickerComponent {
-
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: Date;
 }

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-datepicker.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-datepicker.ts
@@ -6,7 +6,7 @@ import { Component, Input } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-daterange.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-daterange.ts
@@ -5,7 +5,7 @@ import { Component, Input } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-daterange.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-daterange.ts
@@ -3,7 +3,14 @@ import { Component, Input } from "@angular/core";
 @Component({
   selector: `sds-readonly-daterange`,
   template: `
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span class="text-bold"> 
       {{value[daterangepickerOptions.fromDateKey] | date: 'mediumDate'}} - 
       {{value[daterangepickerOptions.toDateKey] | date: 'mediumDate'}}
@@ -11,6 +18,7 @@ import { Component, Input } from "@angular/core";
   `
 })
 export class ReadonlyDaterangeComponent {
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() daterangepickerOptions = {

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-fileinfo.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-fileinfo.ts
@@ -3,7 +3,14 @@ import { Component, Input, OnInit } from "@angular/core";
 @Component({
   selector: `sds-readonly-fileinfo`,
   template: `
-      <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span *ngIf="!value; else definedValues" class="text-bold">&mdash;</span>
 
     <ng-template #definedValues>
@@ -14,6 +21,7 @@ import { Component, Input, OnInit } from "@angular/core";
   `
 })
 export class ReadonlyFileinfoComponent implements OnInit {
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() fileInfoOptions: any[];

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-fileinfo.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-fileinfo.ts
@@ -5,7 +5,7 @@ import { Component, Input, OnInit } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-input.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-input.ts
@@ -5,7 +5,7 @@ import { Component, Input } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-input.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-input.ts
@@ -3,11 +3,19 @@ import { Component, Input } from "@angular/core";
 @Component({
   selector: `sds-readonly-input`,
   template: `
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span class="text-bold">{{value ? value : '&mdash;'}}</span>
   `
 })
 export class ReadonlyInputComponent {
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
 

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-multicheckbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-multicheckbox.ts
@@ -13,7 +13,7 @@ import { Component, Input, OnInit } from '@angular/core';
   </ng-template>`,
 })
 export class ReadonlyMulticheckboxComponent implements OnInit {
-
+  @Input() templateOptions: any = {};
   @Input() label: string;
   @Input() value: any;
   @Input() multicheckboxOptions: any[];

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-multicheckbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-multicheckbox.ts
@@ -3,7 +3,14 @@ import { Component, Input, OnInit } from '@angular/core';
 @Component({
   selector: `sds-readonly-multicheckbox`,
   template: `
-  <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to?.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
   <span *ngIf="!value; else definedValues" class="text-bold">&mdash;</span>
 
   <ng-template #definedValues>
@@ -13,7 +20,7 @@ import { Component, Input, OnInit } from '@angular/core';
   </ng-template>`,
 })
 export class ReadonlyMulticheckboxComponent implements OnInit {
-  @Input() templateOptions: any = {};
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() multicheckboxOptions: any[];

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-radio.ts
@@ -3,7 +3,14 @@ import { Component, Input, OnInit } from "@angular/core";
 @Component({
   selector: `sds-readonly-radio`,
   template: `
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span *ngIf="!value; else definedValues" class="text-bold">&mdash;</span>
 
     <ng-template #definedValues>
@@ -14,7 +21,7 @@ import { Component, Input, OnInit } from "@angular/core";
   `,
 })
 export class ReadonlyRadioComponent implements OnInit {
-
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() radioOptions: any[];

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-radio.ts
@@ -5,7 +5,7 @@ import { Component, Input, OnInit } from "@angular/core";
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-select.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-select.ts
@@ -5,7 +5,7 @@ import { Component, Input, OnInit } from '@angular/core';
   template: `
     <label class="usa-label">
       <span
-      *ngIf="to.tagText"
+      *ngIf="to?.tagText"
       class="usa-tag"
       [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
       >{{ to.tagText }}</span>

--- a/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-select.ts
+++ b/libs/packages/sam-formly/src/lib/formly/readonly/readonly-types/readonly-select.ts
@@ -3,12 +3,19 @@ import { Component, Input, OnInit } from '@angular/core';
 @Component({
   selector: `sds-readonly-select`,
   template: `
-    <label class="usa-label">{{label}}</label>
+    <label class="usa-label">
+      <span
+      *ngIf="to.tagText"
+      class="usa-tag"
+      [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
+      >{{ to.tagText }}</span>
+      {{label ? label : to.label}}
+    </label>
     <span [innerHTML]="displayValue.label" class="text-bold"></span>
   `
 })
 export class ReadonlySelectComponent implements OnInit {
-  
+  @Input() to: any = {}; // template options
   @Input() label: string;
   @Input() value: any;
   @Input() selectOptions: any[];


### PR DESCRIPTION
## Description
Expand readonly components to accept template options to allow tags in labels

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

