### PR TITLE
Allow arial label options for no matches template button

### DIFF
--- a/libs/documentation/src/lib/components/result-list/demos/basic/result-list-basic.component.ts
+++ b/libs/documentation/src/lib/components/result-list/demos/basic/result-list-basic.component.ts
@@ -44,6 +44,7 @@ export class ResultListBasic {
               id: 'backward',
               text: 'Go back',
               action: this.gobackbutton,
+              ariaLabel: 'Go Back'
             },
           ],
         },

--- a/libs/packages/components/src/lib/search-result-list/model/search-results.model.ts
+++ b/libs/packages/components/src/lib/search-result-list/model/search-results.model.ts
@@ -18,4 +18,5 @@ export class Button {
   text: string;
   classes: string;
   action: any;
+  ariaLabel?: string;
 }

--- a/libs/packages/components/src/lib/search-result-list/search-result-list.component.html
+++ b/libs/packages/components/src/lib/search-result-list/search-result-list.component.html
@@ -70,7 +70,7 @@
               <h1 class="sds-card__title">{{msg.title}}</h1>
               <p [innerHTML]="msg.message"></p>
               <div class="sds-card__buttons">
-                <button *ngFor="let button of msg.buttons" class="usa-button"
+                <button *ngFor="let button of msg.buttons" class="usa-button" [attr.aria-label]="button.ariaLabel"
                   [ngClass]="button.classes ? button.classes : 'usa-button--outline'" (click)="button.action()">
                   {{button.text}}
                 </button>


### PR DESCRIPTION
## Description
Adds ariaLabel option for button list in results-list model

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

