### PR TITLE
make optional params for SearchSettings optional

### DIFF
--- a/libs/packages/components/src/lib/search/search.component.ts
+++ b/libs/packages/components/src/lib/search/search.component.ts
@@ -16,11 +16,11 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 export class SearchSettings {
   public placeholder = 'Search';
   public ariaLabel? = 'Search';
-  public size: string;
-  public inputClass: string;
-  public parentSelector: string;
+  public size?: string;
+  public inputClass?: string;
+  public parentSelector?: string;
   public id?: string;
-  public dropdown: any = {
+  public dropdown?: any = {
     id: 'searchOptions',
     placeholder: '-Select-',
     options: [],


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
fix SearchSettings fields to be correctly marked as optional to allow for accurate type checking

## Description
make SearchSettings type safe

## Motivation and Context
we have turned on typechecking and having all fields required breaks our code and is unnecessary when using default values

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

