### PR TITLE
Resolve recursive navigation due to page params

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -233,16 +233,24 @@ export class SearchListLayoutComponent implements OnInit {
     const queryString = window.location.search.substring(1);
     let queryObj = qs.parse(queryString, { allowPrototypes: true });
 
+    let skipHistoryOnNav = false;
+
     if (queryObj.hasOwnProperty('sfm')) {
       queryObj['sfm'] = {};
     }
 
+    // Prevent recursive navigation when adding default page to search
+    if (!queryObj.page || !queryObj.pageSize) {
+      skipHistoryOnNav = true;
+    }
+
     queryObj['page'] = this.page.pageNumber
-      ? this.page.pageNumber.toString()
-      : '1';
+    ? this.page.pageNumber.toString()
+    : '1';
     queryObj['pageSize'] = this.page.pageSize
       ? this.page.pageSize.toString()
       : '25';
+
     queryObj['sort'] = this.sortField ? this.sortField.toString() : '';
     queryObj['sfm'] = this.filterData;
     const params = this.convertToParam(queryObj);
@@ -261,6 +269,7 @@ export class SearchListLayoutComponent implements OnInit {
         queryParams: params,
         queryParamsHandling: this.configuration.queryParamsHandling,
         fragment: window.location.hash?.length > 1 ? window.location.hash.substring(1) : undefined,
+        replaceUrl: skipHistoryOnNav,
       });
     } else {
       const urlTree = this.router.parseUrl(this.loc.path());


### PR DESCRIPTION
## Description
Resolve issue described in #754
Perform navigation by skipping history when adding default page number or size

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

