### PR TITLE
Remove false values from query param

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -296,8 +296,9 @@ export class SearchListLayoutComponent implements OnInit {
     queryString.split('&').forEach((pair) => {
       if (pair !== '') {
         const splitpair = pair.split('=');
-        target[splitpair[0]] =
-          splitpair[1] === '' || splitpair[1] === 'false' ? null : splitpair[1];
+        if (splitpair[1] != '' && splitpair[1] != 'false') {
+          target[splitpair[0]] = splitpair[1]
+        }
       }
     });
     return target;


### PR DESCRIPTION
## Description
Resolves issue where false values in sds-filters was being set to null in query params by layout. False values will be ignored instead and simply not be included in search history
#790 

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

