### PR TITLE
Update html for loading boxes

### DIFF
--- a/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.html
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.html
@@ -118,18 +118,22 @@
     <subawardee-demo (subawardeeUpdate)="updateSubawardee($event)" [subawardees]="model.subawardee"></subawardee-demo>
   </ng-container>
   <ng-template #loading>
-    <div class="grid-container">
-      <div class="sds-load grid-row">
-        <div class="grid-col-5 sds-load__title"></div>
-        <div class="grid-col-auto sds-load__circle"></div>
-      </div>
-      <div class="sds-load grid-row">
-        <div class="tablet:grid-col-fill sds-load__content"></div>
-        <div class="tablet:grid-col-fill sds-load__content"></div>
-        <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
-        <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
+    <div *ngFor="let a of loadingArray">
+      <hr>
+      <div class="grid-container">
+        <div class="sds-load grid-row">
+          <div class="grid-col-5 sds-load__title"></div>
+          <div class="grid-col-auto sds-load__circle"></div>
+        </div>
+        <div class="sds-load">
+          <div class="tablet:grid-col-fill sds-load__element"></div>
+        </div>
+        <div class="sds-load">
+          <div class="grid-col-8 height-4 sds-load__content"></div>
+        </div>
       </div>
     </div>
+    <hr>
   </ng-template>
 </ng-template>
 

--- a/libs/packages/components/src/lib/search-result-list/search-result-list.component.html
+++ b/libs/packages/components/src/lib/search-result-list/search-result-list.component.html
@@ -84,16 +84,20 @@
 </div>
 
 <ng-template #loading>
-  <div class="grid-container">
-    <div class="sds-load grid-row">
-      <div class="grid-col-5 sds-load__title"></div>
-      <div class="grid-col-auto sds-load__circle"></div>
-    </div>
-    <div class="sds-load grid-row">
-      <div class="tablet:grid-col-fill sds-load__content"></div>
-      <div class="tablet:grid-col-fill sds-load__content"></div>
-      <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
-      <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
+  <div *ngFor="let a of loadingArray">
+    <hr>
+    <div class="grid-container">
+      <div class="sds-load grid-row">
+        <div class="grid-col-5 sds-load__title"></div>
+        <div class="grid-col-auto sds-load__circle"></div>
+      </div>
+      <div class="sds-load">
+        <div class="tablet:grid-col-fill sds-load__element"></div>
+      </div>
+      <div class="sds-load">
+        <div class="grid-col-8 height-4 sds-load__content"></div>
+      </div>
     </div>
   </div>
+  <hr>
 </ng-template>

--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.html
@@ -50,11 +50,11 @@
         <div class="grid-col-5 sds-load__title"></div>
         <div class="grid-col-auto sds-load__circle"></div>
       </div>
-      <div class="sds-load grid-row">
-        <div class="tablet:grid-col-fill sds-load__content"></div>
-        <div class="tablet:grid-col-fill sds-load__content"></div>
-        <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
-        <div class="tablet:grid-col-2 grid-col sds-load__element"></div>
+      <div class="sds-load">
+        <div class="tablet:grid-col-fill sds-load__element"></div>
+      </div>
+      <div class="sds-load">
+        <div class="grid-col-8 height-4 sds-load__content"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Update html for loading template so that the divs are one long horizontal strips on each line instead of coalition of divs in a row. This will allow the horizontal loading animation to move across the entire div rather than break up as each div ends.
Changes do require css from this PR - https://github.com/GSA/sam-styles/pull/473 integrated

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

