### PR TITLE
Minor css and bug fixes to horizontal filters

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -364,7 +364,7 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
       if (result) {
         this.onModelChange(result);
       } else {
-        this.model = this._modelSnapshot;
+        Object.assign(this.model, this._modelSnapshot);
       }
       this.dialogRef = null;
     })

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -50,7 +50,7 @@ import * as qs from 'qs';
           </div>
         </ng-container>
         <ng-container *ngSwitchCase="'popover'">
-        <div #popoverContent class="padding-1 text-left">
+        <div #popoverContent class="padding-1 text-left sds-width-max-content maxw-card-lg">
           <ng-container #fieldComponent></ng-container>
         </div>
           <div


### PR DESCRIPTION
## Description
Makes popover for sds filters slightly larger. Fixes bug where switching from mobile to desktop after opening filter modal would disconnect form model

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

