### PR TITLE
Demo feedback update - caret down should be smaller

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly-filters/advanced-filters/advanced-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/advanced-filters/advanced-filters.component.html
@@ -8,7 +8,7 @@
   [closeOnContentClick]="false" [closeOnClickOutside]="true"
   tabindex="0" aria-label="More Filters">
   More Filters
-  <usa-icon [icon]="'chevron-down'"></usa-icon>
+  <usa-icon [icon]="'chevron-down'" [size]="'sm'"></usa-icon>
   <p #content class="padding-2">
     <formly-form [fields]="popoverContent" (modelChange)="updateSelectedFields($event)"></formly-form>
   </p>

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -50,7 +50,7 @@ import * as qs from 'qs';
           </div>
         </ng-container>
         <ng-container *ngSwitchCase="'popover'">
-        <div #popoverContent class="padding-1 text-left sds-width-max-content maxw-card-lg">
+        <div #popoverContent class="padding-1 text-left sds-width-max-content">
           <ng-container #fieldComponent></ng-container>
         </div>
           <div
@@ -60,7 +60,7 @@ import * as qs from 'qs';
               [closeOnClickOutside]="true"
               tabindex="0" [attr.aria-label]="to.label">
             {{to.label}}
-            <usa-icon [icon]="'chevron-down'"></usa-icon>
+            <usa-icon [icon]="'chevron-down'" [size]="'sm'"></usa-icon>
           </div>
         </ng-container>
         <ng-container *ngSwitchDefault>


### PR DESCRIPTION
## Description
Updates size of down caret in horizontal filter popover to be slightly smaller

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

