### PR TITLE
Add output event on sortfield change and on reset click

### DIFF
--- a/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
+++ b/libs/packages/layouts/src/lib/feature/search-list-layout/search-list-layout.component.ts
@@ -9,6 +9,8 @@ import {
   OnInit,
   ChangeDetectorRef,
   HostListener,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import * as qs from 'qs';
@@ -63,6 +65,8 @@ export class SearchListLayoutComponent implements OnInit {
   @Input() configuration: SearchListConfiguration;
 
   @Input() enableApiCall: boolean = true;
+
+  @Output() sortFieldChange = new EventEmitter<string>();
 
   /**
    * Set to true when either filter is empty or filter is equal to default model
@@ -358,6 +362,7 @@ export class SearchListLayoutComponent implements OnInit {
   onSelectChange() {
     this.page.pageNumber = 1;
     this.updateContent();
+    this.sortFieldChange.emit(this.sortField);
   }
 
   /**

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -9,7 +9,7 @@
       </sds-advanced-filters>
     </div>
     <div class="grid-col text-right">
-      <sds-formly-reset [options]="options" [defaultModel]="defaultModel"></sds-formly-reset>
+      <sds-formly-reset [options]="options" [defaultModel]="defaultModel" (resetClicked)="resetClicked.emit()"></sds-formly-reset>
     </div>
   </div>
 </div>
@@ -41,7 +41,7 @@
   </div>
 
   <div *ngIf="showReset" class="horizontal-reset margin-left-2 text-right">
-    <sds-formly-reset [options]="options" [defaultModel]="{}"></sds-formly-reset>
+    <sds-formly-reset [options]="options" [defaultModel]="{}" (resetClicked)="resetClicked.emit()"></sds-formly-reset>
   </div>
 </div>
 
@@ -85,7 +85,7 @@
       </formly-form>
       <div class="grid-row margin-top-2">
         <div class="grid-col text-right">
-          <sds-formly-reset [options]="data.options" [defaultModel]="{}"></sds-formly-reset>
+          <sds-formly-reset [options]="data.options" [defaultModel]="{}" (resetClicked)="resetClicked.emit()"></sds-formly-reset>
         </div>
       </div>
     </div>

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -111,6 +111,7 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   // TODO: check type -- Formly models are typically objects
   @Output() filterChange = new EventEmitter<object>();
   @Output() showInactiveFiltersChange = new EventEmitter<boolean>();
+  @Output() resetClicked = new EventEmitter();
 
   chips: ReadonlyDataType[] = [];
   dialogRef: SdsDialogRef<any>;

--- a/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.ts
@@ -20,6 +20,8 @@ export class SdsFormlyResetComponent {
    */
   @Input() classes: string[] = ['usa-button', 'usa-button--unstyled'];
 
+  @Output() resetClicked = new EventEmitter();
+
   resetAll() {
 
     if (this.defaultModel) {
@@ -27,6 +29,7 @@ export class SdsFormlyResetComponent {
     } else {
       this.options.resetModel();
     }
+    this.resetClicked.emit();
   }
 
 }


### PR DESCRIPTION
## Description
Add output events for applications to listen and react to:
layout's sort by filter value changes
Sds-filter's reset button click event

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

