### PR TITLE
Add demo for horizontal layout

### DIFF
--- a/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.html
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.html
@@ -14,3 +14,4 @@
     </sds-filters>
   </div>
 </div>
+

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
@@ -1,10 +1,8 @@
 import { Component } from "@angular/core";
 import { FormlyFieldConfig, FormlyFormOptions } from "@ngx-formly/core";
-
-
 @Component({
   selector: `horizontal-filter-demo`,
-  templateUrl: `horizontal-filter.component.html`
+  templateUrl: `horizontal-filter.component.html`,
 })
 export class HorizontalFilterDemo {
   options: FormlyFormOptions = {};

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.html
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.html
@@ -1,0 +1,3 @@
+<div class="margin-bottom-2 margin-top-2 sds-tile--outline">
+  <sds-filters [fields]="noPopupConfig" (filterChange)="onFilterChange($event)"> </sds-filters>
+</div>

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.ts
@@ -37,7 +37,7 @@ export class HorizontalLayoutComponent {
       fieldGroupClassName: 'grid-row grid-gap-2', // Set up grid row so that form controls will be on same row
       fieldGroup: [
         {
-          key: 'entity.type',
+          key: 'userRole',
           type: 'select',
           className: 'tablet:grid-col-5 mobile-lg:grid-col-12', // Set up column space for input based on screensize
           templateOptions: {
@@ -52,7 +52,7 @@ export class HorizontalLayoutComponent {
           },
         },
         {
-          key: 'multiple.default.entity.title',
+          key: 'userPurpose',
           type: 'autocomplete',
           className: 'tablet:grid-col-5 mobile-lg:grid-col-12', // Set up column space for input based on screensize
           templateOptions: {

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.component.ts
@@ -1,0 +1,86 @@
+import { Component, Injectable } from '@angular/core';
+import { SDSAutocompletelConfiguration, SDSAutocompleteServiceInterface, SDSHiercarchicalServiceResult, SDSSelectedItemModel, SelectionMode } from "@gsa-sam/components";
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { Observable, of } from "rxjs";
+
+/** Service setup to provide static options for autocomplete dropdown */
+@Injectable()
+export class AutocompleteDropdownMenu implements SDSAutocompleteServiceInterface {
+  getDataByText(currentItems: number, searchValue?: string): Observable<SDSHiercarchicalServiceResult> {
+    const options = [
+      { 'id': '1', 'name': 'Federal Acquisition', 
+        'subtext': 'The process by which government contract entities to provide goods or services on the government\'s behalf. This is done via bidding on contracts that the government releases to interested businesses.'},
+      { 'id': '2', 'name': 'Federal Assistance', 'subtext': 'Organizations attempting to recieve financial assistance in the way of loans or grants'},
+      { 'id': '3', 'name': 'All Topics', 'subtext': '' }
+    ];
+    return of({totalItems: 3, items: options});
+  }
+}
+
+@Component({
+  selector: 'gsa-sam-horizontal-layout',
+  templateUrl: './horizontal-layout.component.html',
+  providers: [
+    AutocompleteDropdownMenu,
+  ]
+})
+export class HorizontalLayoutComponent {
+
+  public settings = new SDSAutocompletelConfiguration();
+
+  public autocompleteModel = new SDSSelectedItemModel();
+
+  /** Formly config for demo */
+  noPopupConfig: FormlyFieldConfig[] = [
+    {
+      key: 'filters',
+      fieldGroupClassName: 'grid-row grid-gap-2', // Set up grid row so that form controls will be on same row
+      fieldGroup: [
+        {
+          key: 'entity.type',
+          type: 'select',
+          className: 'tablet:grid-col-5 mobile-lg:grid-col-12', // Set up column space for input based on screensize
+          templateOptions: {
+            label: 'I am a...',
+            labelClass: 'text-bold', // Add bold style to label
+            hideOptional: true,
+            options: [
+              { label: 'U.S. Federal User', value: 'fedUser' },
+              { label: 'U.S. Non-Fed User', value: 'nonFedUser' },
+              { label: 'Neither', value: 'none' },
+            ],
+          },
+        },
+        {
+          key: 'multiple.default.entity.title',
+          type: 'autocomplete',
+          className: 'tablet:grid-col-5 mobile-lg:grid-col-12', // Set up column space for input based on screensize
+          templateOptions: {
+            label: 'I am interested in...',
+            labelClass: 'text-bold', // Add bold style to label
+            hideOptional: true,
+            service: this.service,
+            configuration: this.settings,
+            model: this.autocompleteModel,
+          },
+        },
+      ],
+    },
+  ];
+
+  constructor(
+    public service: AutocompleteDropdownMenu
+  ) {
+    this.settings.id = 'noPopupHorizontalAutocomplete';
+    this.settings.primaryKeyField = 'id';
+    this.settings.primaryTextField = 'name';
+    this.settings.secondaryTextField = 'subtext';
+    this.settings.selectionMode = SelectionMode.SINGLE;
+    this.settings.inputReadOnly = true; // Set autocomplete as read only
+    this.settings.ariaLabelText = 'Select your purpose of registration'
+  }
+
+  onFilterChange($event) {
+    console.log($event);
+  }
+}

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.module.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-layout/horizontal-layout.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HorizontalLayoutComponent } from './horizontal-layout.component';
+import { SdsFiltersModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+
+
+@NgModule({
+  declarations: [
+    HorizontalLayoutComponent
+  ],
+  imports: [
+    CommonModule,
+    SdsFiltersModule,
+    FormlyModule.forRoot(),
+    ReactiveFormsModule,
+    FormsModule,
+  ]
+})
+export class HorizontalLayoutModule { }

--- a/libs/documentation/src/lib/components/filters/filters.module.ts
+++ b/libs/documentation/src/lib/components/filters/filters.module.ts
@@ -21,6 +21,8 @@ import { FiltersDefaultValueComponent } from './demos/defaultValues/filters-defa
 import { FiltersDefaultValueModule } from './demos/defaultValues/filters-default-value.module';
 import { HorizontalFilterDemo } from './demos/horizontal-filter/horizontal-filter.component';
 import { HorizontalFilterModule } from './demos/horizontal-filter/horizontal-filter.module';
+import { HorizontalLayoutComponent } from './demos/horizontal-layout/horizontal-layout.component';
+import { HorizontalLayoutModule } from './demos/horizontal-layout/horizontal-layout.module';
 
 declare var require: any;
 const DEMOS = {
@@ -40,6 +42,16 @@ const DEMOS = {
     module: require('!!raw-loader!./demos/optional/filters-optional.module'),
     path: 'libs/documentation/src/lib/components/filters/demos/optional',
   },
+  horizontalLayout: {
+    title: 'Horizontal Layout',
+    type: HorizontalLayoutComponent,
+    code: require('!!raw-loader!./demos/horizontal-layout/horizontal-layout.component'),
+    markup: require('!!raw-loader!./demos/horizontal-layout/horizontal-layout.component.html'),
+    module: require('!!raw-loader!./demos/horizontal-layout/horizontal-layout.module'),
+    path:
+      'libs/documentation/src/lib/components/filters/demos/horizontal-layout',
+  },
+
   horizontalFilters: {
     title: 'Horizontal Filter',
     type: HorizontalFilterDemo,
@@ -110,6 +122,7 @@ export const ROUTES = [
     FiltersShowInactiveFilterValuesModule,
     FiltersDefaultValueModule,
     HorizontalFilterModule,
+    HorizontalLayoutModule,
   ],
 })
 export class FiltersModule {

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
@@ -117,8 +117,7 @@
 }
 
 .hide-cursor {
-  color: transparent;
-  text-shadow: 0 0 0;
+  caret-color: transparent;
 }
 
 input::-ms-clear {
@@ -128,5 +127,4 @@ input::-ms-clear {
 .sds-autocomplete {
   position: relative;
   min-width: 30rem;
-  max-width: max-content;
 }

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
@@ -629,10 +629,7 @@ export class SDSAutocompleteSearchComponent implements ControlValueAccessor {
   }
 
   getClass() {
-    return this.configuration.inputReadOnly &&
-      this.configuration.selectionMode === SelectionMode.MULTIPLE
-      ? 'hide-cursor'
-      : '';
+    return this.configuration.inputReadOnly ? 'hide-cursor' : '';
   }
 
   registerOnChange(fn: any): void {

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -25,7 +25,7 @@ import * as qs from 'qs';
               class="sds-accordion__panel"
               [expanded]="modelHasValue()"
             >
-              <sds-accordion-title>{{ to.label }}</sds-accordion-title>
+              <sds-accordion-title><span [attr.class]="to.labelClass">{{ to.label }}</span></sds-accordion-title>
               <sds-accordion-content>
                 <ng-container #fieldComponent></ng-container>
               </sds-accordion-content>
@@ -42,7 +42,7 @@ import * as qs from 'qs';
               *ngIf="!to.hideLabel"
               [attr.aria-hidden]="!to.announceLabel ? undefined : 'true'"
             >
-              {{ to.label }}
+              <span [attr.class]="to.labelClass">{{ to.label }}</span>
             </div>
             <div class="sds-panel__body">
               <ng-container #fieldComponent></ng-container>

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/label.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/label.wrapper.ts
@@ -29,7 +29,7 @@ import { FieldWrapper } from '@ngx-formly/core';
           [ngClass]="to.tagClass ? to.tagClass : 'sds-tag--info-white'"
           >{{ to.tagText }}</span
         >
-        <span>{{ to.label }}</span>
+        <span [attr.class]="to.labelClass">{{ to.label }}</span>
         <span *ngIf="!to.required && !to.hideOptional"> (Optional)</span>
       </label>
       <ng-container #fieldComponent></ng-container>


### PR DESCRIPTION
## Description
Small demo for how fields can be displayed horizontally in sds filters through grid css classes
Updates autocomplete to hide cursor in both multi or single select view during input readonly mode
Updates label to allow labelClass template option for defining additional css to labels

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

