### PR TITLE
IAE-56716: Update ngx-uswds-icons version to 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2931,9 +2931,9 @@
       }
     },
     "@gsa-sam/ngx-uswds-icons": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@gsa-sam/ngx-uswds-icons/-/ngx-uswds-icons-0.0.6.tgz",
-      "integrity": "sha512-wX3UmNfTK+8POMR0kinutF7/KOWHjHttuN/lOrx07QMRxsFM/MK5+noTNSjmulYSmAEmaDngVMPNtW5o/niaog==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@gsa-sam/ngx-uswds-icons/-/ngx-uswds-icons-0.0.7.tgz",
+      "integrity": "sha512-VZCOXD1aI4StBTdWHRPyr0vT2W3NmrCnZvL8RP0HryRpxqyucTKP/KYk5+3IW+8cYJYdY9oCQD4cYa2jSMynDg==",
       "requires": {
         "ngx-bootstrap-icons": "^1.5.0",
         "tslib": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@gsa-sam/components": "10.0.35",
     "@gsa-sam/layouts": "10.0.35",
     "@gsa-sam/ngx-uswds": "0.0.1",
-    "@gsa-sam/ngx-uswds-icons": "0.0.6",
+    "@gsa-sam/ngx-uswds-icons": "0.0.7",
     "@gsa-sam/sam-formly": "10.0.35",
     "@gsa-sam/sam-material-extensions": "10.0.35",
     "@gsa-sam/sam-styles": "0.0.118",


### PR DESCRIPTION
## Description
Increment the version of ngx-uswds-icons used by sam design system, this version was created to address issue raised by https://github.com/GSA/sam-styles/issues/469 by adding a class, icon-display-block, to usa-icon which sets display:block on the icon's svg. 

## Motivation and Context
Needed to address issue raised by https://github.com/GSA/sam-styles/issues/469 by adding a class, icon-display-block, to usa-icon which sets display:block on the icon's svg. 


## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

