### PR TITLE
Add display modifier function for autocomplete chips

### DIFF
--- a/libs/documentation/src/lib/pages/layout/filter.service.ts
+++ b/libs/documentation/src/lib/pages/layout/filter.service.ts
@@ -8,15 +8,19 @@ import {
 } from '@gsa-sam/components';
 import { Injectable } from '@angular/core';
 import { SdsFormlyTypes } from '@gsa-sam/sam-formly';
+import { Subject } from 'rxjs';
 
 @Injectable()
 export class FilterService {
   public settings = new SDSAutocompletelConfiguration();
   public autocompleteModel = new SDSSelectedItemModel();
-
+  
   public model = {};
   public form = new FormGroup({});
   options: FormlyFormOptions = {};
+
+  public keywordChangeSubject = new Subject();
+
   public fields: FormlyFieldConfig[] = [
     {
       key: 'keyword',
@@ -33,9 +37,11 @@ export class FilterService {
             templateOptions: {
               tabHeader: 'Simple Search'
             },
+            fieldGroupClassName: 'grid-row',
             fieldGroup: [
               {
                 key: 'keywordRadio',
+                className: 'grid-col-5',
                 type: 'radio',
                 defaultValue: 'anyWords',
                 templateOptions: {
@@ -48,16 +54,22 @@ export class FilterService {
                       label: 'All Words',
                       value: 'allWords'
                     },
-                    {
-                      label: 'Exact Match',
-                      value: 'exactMatch'
-                    }
-                  ]
+                  ],
+                },
+              },
+              {
+                className: 'grid-col-6 margin-top-auto margin-left-auto',
+                key: 'keywordExactPhrase',
+                type: 'checkbox',
+                templateOptions: {
+                  label: 'Exact Phrase',
+                  hideOptional: true,
                 }
               },
               {
                 key: 'keywordTags',
                 type: 'autocomplete',
+                className: 'grid-col-12',
                 templateOptions: {
                   expand: false,
                   configuration: {
@@ -68,6 +80,10 @@ export class FilterService {
                     selectionMode: SelectionMode.MULTIPLE,
                     autocompletePlaceHolderText: "",
                     isTagModeEnabled: true,
+                    // Bind context of this service so we have access to radio button value
+                    displayModifierFn: this.displayModifierFn.bind(this),
+                    // Add observable so that we can tell autocomplete to run change detection later when radio option changes
+                    registerChanges$: this.keywordChangeSubject.asObservable(),
                   }
                 }
               }]
@@ -315,5 +331,26 @@ export class FilterService {
     this.settings.selectionMode = SelectionMode.MULTIPLE;
     this.settings.autocompletePlaceHolderText = 'Alaska';
     this.settings.debounceTime = 350;
+  }
+
+  displayModifierFn(value: string, index: number) {
+    if (index === 0) {
+      return value;
+    }
+
+    // We can do 'this.model' because we binded this service to the function in the config.
+    // So, inside this function, the context 'this' will refer to this service
+    const keywordRadio = this.model['keyword']?.keywordRadio;
+    if (!keywordRadio) {
+      return value;
+    }
+
+    if (keywordRadio === 'allWords') {
+      return `and  ${value}`;
+    } else if (keywordRadio === 'anyWords') {
+      return `or  ${value}`;
+    } else {
+      return value;
+    }
   }
 }

--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.ts
@@ -90,9 +90,20 @@ export class LayoutResponsiveComponent {
       isHistoryEnabled: true,
     };
   }
+
   ngAfterViewInit() {
     this.filterChange$.subscribe((res) => {
       this.resultList.updateFilter(res);
+    });
+
+    // Listen for radio change and refresh autocomplete
+    const keywordGroup = this.fields.find(field => field.key === 'keyword').fieldArray.fieldGroup[0].fieldGroup;
+    keywordGroup.find(keyword => keyword.key === 'keywordRadio').formControl.valueChanges.subscribe(change => {
+      // Refresh autocomplete chips - we do set timeout so that our model for radio option can update first, then
+      // this refresh will update our chips depending on the updated model value
+      setTimeout(() => {
+        this.filterService.keywordChangeSubject.next();
+      });
     });
   }
 

--- a/libs/documentation/src/lib/pages/layout/layout.component.ts
+++ b/libs/documentation/src/lib/pages/layout/layout.component.ts
@@ -64,6 +64,16 @@ export class ResultsLayoutComponent implements AfterViewInit, OnInit {
     this.filterChange$.subscribe((res) => {
       this.resultList.updateFilter(res);
     });
+
+    // Listen for radio change and refresh autocomplete
+    const keywordGroup = this.fields.find(field => field.key === 'keyword').fieldArray.fieldGroup[0].fieldGroup;
+    keywordGroup.find(keyword => keyword.key === 'keywordRadio').formControl.valueChanges.subscribe(change => {
+      // Refresh autocomplete chips - we do set timeout so that our model for radio option can update first, then
+      // this refresh will update our chips depending on the updated model value
+      setTimeout(() => {
+        this.filterService.keywordChangeSubject.next();
+      });
+    });
   }
 
   updateConfig(update: boolean) {

--- a/libs/packages/components/src/lib/autocomplete/models/SDSAutocompletelConfiguration.model.ts
+++ b/libs/packages/components/src/lib/autocomplete/models/SDSAutocompletelConfiguration.model.ts
@@ -1,6 +1,7 @@
 import { SDSSelectedResultConfiguration } from '../../selected-result/models/SDSSelectedResultConfiguration';
 import { SDSAutocompleteSearchConfiguration } from '../../autocomplete-search/models/SDSAutocompleteConfiguration';
 import { SelectionMode } from '../../selected-result/models/sds-selected-item-model-helper';
+import { Observable } from 'rxjs';
 
 export class SDSAutocompletelConfiguration
   implements
@@ -110,4 +111,19 @@ export class SDSAutocompletelConfiguration
    * @default false
    */
   public hideChips: boolean = false;
+
+  /** 
+   * Modifiier function to change display of how primary text field is shown
+   * Allows adding prefix / suffix values when displaying tags
+   */
+  public displayModifierFn: (displayValue: string, index?: number) => string;
+
+  /**
+   * Provides a way for external components to force change detection
+   * on internal components. Any time this observable is emitted, a change
+   * detection will be preformed, ensuring data model and template values are
+   * in sync. This can be useful if some external changes are made and visual
+   * updates need to be made
+   */
+  public registerChanges$: Observable<void>;
 }

--- a/libs/packages/components/src/lib/selected-result/models/SDSSelectedResultConfiguration.ts
+++ b/libs/packages/components/src/lib/selected-result/models/SDSSelectedResultConfiguration.ts
@@ -1,3 +1,4 @@
+import { Observable } from 'rxjs';
 import { SelectionMode } from './sds-selected-item-model-helper';
 
 export class SDSSelectedResultConfiguration {
@@ -26,4 +27,10 @@ export class SDSSelectedResultConfiguration {
    * Mode of the model either allows a single item or multiple items
    */
   public selectionMode: SelectionMode = SelectionMode.SINGLE;
+
+  /** 
+   * Modifiier function to change display of how primary text field is shown
+   * Allows adding prefix / suffix values when displaying tags
+   */
+  public displayModifierFn?: (displayValue: string, index?: number) => string;
 }

--- a/libs/packages/components/src/lib/selected-result/selected-result.component.html
+++ b/libs/packages/components/src/lib/selected-result/selected-result.component.html
@@ -9,7 +9,7 @@
       <ng-container *ngIf="!itemTemplate">
         <div class="sds--tag__item">
           <div>
-            {{ getObjectValue(result, configuration.primaryTextField) }}
+            {{ getObjectValue(result, configuration.primaryTextField, i) }}
           </div>
           <div *ngIf="
               configuration.secondaryTextField &&
@@ -21,7 +21,7 @@
       </ng-container>
       <button *ngIf="!disabled" [attr.aria-label]="
           'Remove Item ' +
-          getObjectValue(result, configuration.primaryTextField)
+          getObjectValue(result, configuration.primaryTextField, i)
         " [class.text-base]="disabled" aria-hidden="false" class="sds-tag__close" (click)="removeItem(result)"
         (keyup.enter)="removeItem(result)">
         <usa-icon [icon]="'x'" size="lg"></usa-icon>

--- a/libs/packages/components/src/lib/selected-result/selected-result.component.ts
+++ b/libs/packages/components/src/lib/selected-result/selected-result.component.ts
@@ -84,8 +84,9 @@ export class SDSSelectedResultComponent implements ControlValueAccessor {
    * Gets the string value from the specifed properties of an object
    * @param object 
    * @param propertyFields comma seperated list with periods depth of object
+   * @param index - the index location of the value in model's item list
    */
-  getObjectValue(object: Object, propertyFields: string): string {
+  getObjectValue(object: Object, propertyFields: string, index?: number): string {
     let value = '';
     let current = object;
     let fieldSplit = propertyFields.split(',');
@@ -104,7 +105,8 @@ export class SDSSelectedResultComponent implements ControlValueAccessor {
       }
       current = object;
     }
-    return value.trim();
+
+    return this.configuration.displayModifierFn ? this.configuration.displayModifierFn(value.trim(), index) : value.trim();
   }
 
 }


### PR DESCRIPTION
## Description
Add a function input option for autocomplete configuration that allows users to modify autocomplete chip display value
Add additional observable users can trigger for when they want to force autocomplete to run change detection

## Motivation and Context
This will allow users to add prefix / suffix as needed to their chips

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

