### PR TITLE
Lock stackblitz demo at 11.0.3

### DIFF
--- a/misc/generate-stackblitzes.ts
+++ b/misc/generate-stackblitzes.ts
@@ -15,11 +15,12 @@ const samFormlyPackage = fs.readJsonSync("libs/packages/sam-formly/package.json"
 const samMaterialExtensions = fs.readJsonSync("libs/packages/sam-material-extensions/package.json");
 
 let dependencies = packageJson.dependencies;
+// Locking version at 11.0.3 - issue with stackblitz is that it does not pick up newly released npm modules for weeks
 const samDependencies = {
-  '@gsa-sam/layouts': samLayoutsPackage.version,
-  '@gsa-sam/components': samComponentsPackage.version,
-  '@gsa-sam/sam-formly': samFormlyPackage.version,
-  '@gsa-sam/sam-material-extensions': samMaterialExtensions.version,
+  '@gsa-sam/layouts': '11.0.3',
+  '@gsa-sam/components': '11.0.3',
+  '@gsa-sam/sam-formly': '11.0.3',
+  '@gsa-sam/sam-material-extensions': '11.0.3',
 };
 
 dependencies = {...dependencies, ...samDependencies};


### PR DESCRIPTION
## Description
As of this PR posting, stackblitz does not recognize 10.0.4 has been released. It's slow to pick up new version release, so locking demo at 11.0.3 temporarily

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

