### PR TITLE
Move action menu and responsive side nav to components package

### DIFF
--- a/apps/sam-design-system-site/src/app/app.component.html
+++ b/apps/sam-design-system-site/src/app/app.component.html
@@ -120,6 +120,11 @@
                 </a>
               </li>
               <li class="usa-sidenav__item">
+                <a [routerLink]="['documentation/components/slide-out']" routerLinkActive="usa-current">
+                  Slide Out
+                </a>
+              </li>
+              <li class="usa-sidenav__item">
                 <a [routerLink]="['documentation/components/tabs']" routerLinkActive="usa-current">
                   Tabs
                 </a>
@@ -135,13 +140,6 @@
                   Video Player
                 </a>
               </li>
-
-
-
-
-
-
-
             </ul>
           </li>
           <li class="margin-y-2">
@@ -365,11 +363,6 @@
               <li class="usa-sidenav__item">
                 <a [routerLink]="['documentation/layout-responsive']" routerLinkActive="usa-current">
                   Responsive Layout
-                </a>
-              </li>
-              <li class="usa-sidenav__item">
-                <a [routerLink]="['documentation/components/slide-out']" routerLinkActive="usa-current">
-                  Slide Out
                 </a>
               </li>
               <li class="usa-sidenav__item">

--- a/libs/documentation/src/lib/components/actions/demos/basic/actions-basic.module.ts
+++ b/libs/documentation/src/lib/components/actions/demos/basic/actions-basic.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActionsBasic } from './actions-basic.component';
-import { SdsActionsMenuModule } from '@gsa-sam/layouts';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 
 
 @NgModule({

--- a/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.module.ts
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.module.ts
@@ -4,8 +4,8 @@ import { StepperAdvancedDemoComponent } from "./stepper-advanced.component";
 import { SdsFormlyModule, SdsStepperModule } from '@gsa-sam/sam-formly';
 import { AddSubawardeeDialogDemo, SubawardeeDemoComponent } from "./subawardee.component";
 import { FormlyModule } from "@ngx-formly/core";
-import { SdsActionsMenuModule, SideToolbarModule } from "@gsa-sam/layouts";
 import { CustomStepperDemo } from "./custom-stepper.component";
+import { SdsSideToolbarModule } from '@gsa-sam/components';
 import {
   NgxBootstrapIconsModule,
   chevronLeft,
@@ -25,10 +25,9 @@ import { IconModule } from '@gsa-sam/ngx-uswds-icons';
     SdsFormlyModule,
     SdsStepperModule,
     FormlyModule,
-    SdsActionsMenuModule,
     IconModule,
     NgxBootstrapIconsModule.pick({ chevronLeft, chevronRight, circle, slashCircleFill, checkCircleFill, question, save, x }),
-    SideToolbarModule,
+    SdsSideToolbarModule,
   ],
   declarations: [
     StepperAdvancedDemoComponent,

--- a/libs/documentation/src/lib/components/result-list/demos/basic/result-list-basic.module.ts
+++ b/libs/documentation/src/lib/components/result-list/demos/basic/result-list-basic.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SdsSearchResultListModule } from '@gsa-sam/components';
 
-import { SdsActionsMenuModule } from '@gsa-sam/layouts';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 import { ResultListBasic } from './result-list-basic.component';
 import { NgxBootstrapIconsModule, book } from 'ngx-bootstrap-icons';
 import { IconModule } from '@gsa-sam/ngx-uswds-icons';

--- a/libs/documentation/src/lib/components/result-list/demos/card/result-list-card-component.module.ts
+++ b/libs/documentation/src/lib/components/result-list/demos/card/result-list-card-component.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SdsSearchResultListModule } from '@gsa-sam/components';
 
-import { SdsActionsMenuModule } from '@gsa-sam/layouts';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 import { ResultListCardComponent } from './result-list-card-component.component';
 import { ResultListCardItemSampleComponent } from './card-item.component';
 import { ResultListCardItemChildSampleComponent } from './child-card-item.component';

--- a/libs/documentation/src/lib/components/result-list/demos/component/result-list-component.module.ts
+++ b/libs/documentation/src/lib/components/result-list/demos/component/result-list-component.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SdsSearchResultListModule, SdsPageModule } from '@gsa-sam/components';
 
-import { SdsActionsMenuModule } from '@gsa-sam/layouts';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 import { ResultListComponent } from './result-list-component.component';
 import { ResultListItemSampleComponent } from './item.component';
 import { ResultListItemChildSampleComponent } from './child-item.component';

--- a/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.module.ts
+++ b/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.module.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SdsSearchResultListModule } from '@gsa-sam/components';
 
-import { SdsActionsMenuModule } from '@gsa-sam/layouts';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 import { ResultListTemplate } from './result-list-template.component';
 import { NgxBootstrapIconsModule, book } from 'ngx-bootstrap-icons';
 import { IconModule } from '@gsa-sam/ngx-uswds-icons';

--- a/libs/documentation/src/lib/pages/layout/layout.module.ts
+++ b/libs/documentation/src/lib/pages/layout/layout.module.ts
@@ -7,6 +7,7 @@ import {
   SdsToolbarModule,
   SdsSideNavigationModule,
   SdsSelectionPanelModule,
+  SdsSideToolbarModule
 } from '@gsa-sam/components';
 import {
   SdsFiltersModule,
@@ -14,7 +15,7 @@ import {
 } from '@gsa-sam/sam-formly';
 
 import { ResultModule } from './result/result.module';
-import { SearchListServiceModule, SideToolbarModule } from '@gsa-sam/layouts';
+import { SearchListServiceModule } from '@gsa-sam/layouts';
 import { FilterService } from './filter.service';
 import { AutocompleteSampleDataService } from './services/autocomplete-sample.service';
 import { LayoutResponsiveComponent } from './layout-responsive/layout-responsive.component';
@@ -31,7 +32,7 @@ import { IconModule } from '@gsa-sam/ngx-uswds-icons';
     SdsSearchResultListModule,
     SearchListServiceModule,
     ResultModule,
-    SideToolbarModule,
+    SdsSideToolbarModule,
     SdsSelectionPanelModule,
   ],
 

--- a/libs/packages/components/src/lib/actions-menu/actions-menu.component.html
+++ b/libs/packages/components/src/lib/actions-menu/actions-menu.component.html
@@ -1,0 +1,17 @@
+<!-- Button that triggers menu (sdsMenuTriggerFor) -->
+<button class="sds-button sds-button--circular" [class.sds-button--primary]="model.trigger.type === 'primary'"
+  [class.sds-button--shadow]="model.trigger.shadow" [class.sds-button--small]="size === 'sm'"
+  [sdsMenuTriggerFor]="menu">
+  <usa-icon [icon]="'three-dots-vertical'" [size]="'1x'"></usa-icon>
+  <span class="usa-sr-only">Toggle Actions</span>
+</button>
+
+<!-- Menu content -->
+<sds-menu #menu="sdsMenu" [size]="size" xPosition="before" overlapTrigger="true">
+  <!-- Menu header (optional) -->
+  <sds-menu-header>Actions</sds-menu-header>
+  <!-- Menu items -->
+  <button *ngFor="let button of model.actions" (click)="clicks.emit(button.id)" sds-menu-item>
+    {{ button.text }}
+  </button>
+</sds-menu>

--- a/libs/packages/components/src/lib/actions-menu/actions-menu.component.ts
+++ b/libs/packages/components/src/lib/actions-menu/actions-menu.component.ts
@@ -8,7 +8,5 @@ export class SdsActionsMenuComponent {
   @Input() model;
   @Input() size: string;
   @Output() clicks = new EventEmitter<string>();
-  constructor() {
-    console.warn('The action menu you are currently using is deprecated. Please instead import SdsActionsMenuModule from @gsa-sam/components')
-  }
+  constructor() {}
 }

--- a/libs/packages/components/src/lib/actions-menu/actions-menu.module.ts
+++ b/libs/packages/components/src/lib/actions-menu/actions-menu.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+
+import { SdsActionsMenuComponent } from './actions-menu.component';
+import { CommonModule } from '@angular/common';
+import { NgxBootstrapIconsModule, threeDotsVertical, x } from 'ngx-bootstrap-icons';
+import { IconModule } from '@gsa-sam/ngx-uswds-icons';
+import { SdsMenuModule } from '../menu/menu.module';
+
+
+@NgModule({
+  imports: [CommonModule, IconModule, SdsMenuModule, NgxBootstrapIconsModule.pick({threeDotsVertical, x})],
+  exports: [SdsActionsMenuComponent],
+  declarations: [SdsActionsMenuComponent],
+  providers: []
+})
+export class SdsActionsMenuModule {}

--- a/libs/packages/components/src/lib/public-api.ts
+++ b/libs/packages/components/src/lib/public-api.ts
@@ -3,6 +3,8 @@ export * from './accordion/accordion.directive';
 export * from './accordion/accordion-item-content.directive';
 export * from './accordion/accordion-item-header.component';
 export * from './accordion/accordion-item.component';
+export * from './actions-menu/actions-menu.component';
+export * from './actions-menu/actions-menu.module'
 export * from './page/page.module';
 export * from './page/page.component';
 export * from './toolbar/toolbar.module';
@@ -21,6 +23,8 @@ export * from './selected-result/models/SDSSelectedResultConfiguration';
 export * from './selected-result/models/sds-selected-item-model-helper';
 export * from './side-navigation/side-navigation.module';
 export * from './side-navigation/side-navigation.component';
+export * from './side-toolbar/side-toolbar.module';
+export * from './side-toolbar/side-toolbar.component';
 export * from './search-result-list/search-result-list.module';
 export * from './search-result-list/search-result-list.component';
 export * from './common-navigation/common-navigation-model';

--- a/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.html
+++ b/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.html
@@ -1,0 +1,10 @@
+<div *ngIf="!isResponsiveView">
+  <ng-container *ngTemplateOutlet="template"></ng-container>
+</div>
+
+<div *ngIf="isResponsiveView">
+  <button class="usa-button usa-button--accent-cool usa-button--hover text-secondary-dar" id="responsiveViewButton"
+    (click)="onResponsiveViewButtonClicked()" [attr.aria-label]="responsiveButtonText">
+    {{responsiveButtonText}}
+  </button>
+</div>

--- a/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.spec.ts
+++ b/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.spec.ts
@@ -1,0 +1,44 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SdsDialogModule, SdsDialogService } from '@gsa-sam/components';
+
+import { SdsSideToolbarComponent } from './side-toolbar.component';
+
+describe('SideToolbarComponent', () => {
+  let component: SdsSideToolbarComponent;
+  let fixture: ComponentFixture<SdsSideToolbarComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SdsDialogModule,
+      ],
+      declarations: [ SdsSideToolbarComponent ],
+      providers: [
+        SdsDialogService
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SdsSideToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('Should display advanced search button when mobile view is enabled', () => {
+    let responsiveViewButton = fixture.debugElement.query(By.css('#responsiveViewButton'));
+    expect(responsiveViewButton).toBeNull();
+
+    component.isResponsiveView = true;
+    fixture.detectChanges();
+
+    responsiveViewButton = fixture.debugElement.query(By.css('#responsiveViewButton'));
+    expect(responsiveViewButton).toBeDefined();
+  });
+});

--- a/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.ts
+++ b/libs/packages/components/src/lib/side-toolbar/side-toolbar.component.ts
@@ -8,17 +8,18 @@ import {
   Output,
   TemplateRef,
 } from '@angular/core';
-import { SdsDialogRef, SdsDialogService } from '@gsa-sam/components';
+import { SdsDialogRef } from '../dialog/dialog-ref';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { Subscription } from 'rxjs';
-import { SdsDialogConfig } from '@gsa-sam/components';
+import { SdsDialogConfig } from '../dialog/dialog-config';
+import { SdsDialogService } from '../dialog/dialog';
 
 @Component({
   selector: 'sds-side-toolbar',
   templateUrl: './side-toolbar.component.html',
   styleUrls: ['./side-toolbar.component.scss'],
 })
-export class SideToolbarComponent implements OnInit, OnDestroy {
+export class SdsSideToolbarComponent implements OnInit, OnDestroy {
   @ContentChild(TemplateRef) template: TemplateRef<any>;
 
   // Text for button in responsive view
@@ -40,9 +41,7 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
   constructor(
     private sdsDialogService: SdsDialogService,
     private breakpointObserver: BreakpointObserver // Will watch for changes between mobile and non-mobile screen size
-  ) {
-    console.warn('The side toolbar you are currently using is deprecated. Please instead import SdsToolbarModule from @gsa-sam/components')
-  }
+  ) {}
 
   ngOnInit() {
     this.observeViewChange();

--- a/libs/packages/components/src/lib/side-toolbar/side-toolbar.module.ts
+++ b/libs/packages/components/src/lib/side-toolbar/side-toolbar.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SdsSideToolbarComponent } from './side-toolbar.component';
+import { SdsDialogModule } from '../dialog/dialog.module';
+
+@NgModule({
+  declarations: [SdsSideToolbarComponent],
+  imports: [
+    CommonModule, 
+    SdsDialogModule,
+  ], exports: [SdsSideToolbarComponent],
+})
+export class SdsSideToolbarModule { }

--- a/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
+++ b/libs/packages/layouts/src/lib/feature/side-toolbar/side-toolbar.component.ts
@@ -41,7 +41,7 @@ export class SideToolbarComponent implements OnInit, OnDestroy {
     private sdsDialogService: SdsDialogService,
     private breakpointObserver: BreakpointObserver // Will watch for changes between mobile and non-mobile screen size
   ) {
-    console.warn('The side toolbar you are currently using is deprecated. Please instead import SdsToolbarModule from @gsa-sam/components')
+    console.warn('The side toolbar you are currently using is deprecated. Please instead import SdsSideToolbarModule from @gsa-sam/components')
   }
 
   ngOnInit() {

--- a/libs/packages/layouts/src/lib/feature/subheader/subheader.module.ts
+++ b/libs/packages/layouts/src/lib/feature/subheader/subheader.module.ts
@@ -13,7 +13,7 @@ import {
   SdsSubheaderDrawerComponent,
   SdsDrawerContentComponent
 } from './subheader.component';
-import { SdsActionsMenuModule } from '../actions-menu/actions-menu.module';
+import { SdsActionsMenuModule } from '@gsa-sam/components';
 import { SdsDrawerCommunicationService } from './drawer-communication.service';
 import { NgxBootstrapIconsModule, threeDotsVertical } from 'ngx-bootstrap-icons';
 import { IconModule } from '@gsa-sam/ngx-uswds-icons';


### PR DESCRIPTION
## Description
Moves the action menu and side-toolbar components out of layout package to component package. These two components currently do still exist in layouts in order to give time for users to switch dependency to use @gsa-sam/components rather than layouts. There is a deprecated warning message thrown to console however informing devs to switch their dependency.

## Motivation and Context
separating layouts from the other gsa packages

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

