### PR TITLE
Update circle ci to also run prod build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npm run publish-libs -- --dry-run
+      - run: npm run publish:libs -- --dry-run
       - run: npm run test:components
       - run: npm run test:material-extensions
       - run: npm run test:sam-formly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npm publish-libs -- --dry-run
+      - run: npm run publish-libs -- --dry-run
       - run: npm run test:components
       - run: npm run test:material-extensions
       - run: npm run test:sam-formly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - checkout
       - run: npm install
+      - run: npm publish-libs -- --dry-run
       - run: npm run test:components
       - run: npm run test:material-extensions
       - run: npm run test:sam-formly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - checkout
       - run: npm install
-      - run: npm run publish:libs -- --dry-run
       - run: npm run test:components
       - run: npm run test:material-extensions
       - run: npm run test:sam-formly
       - run: npm run test:layouts
+      - run: npm run publish:libs -- --dry-run
       - store_artifacts:
           path: coverage
           destination: code-coverage


### PR DESCRIPTION
## Description
Updates the circle-ci script to run the publish:libs script in dry run so that all packages also get a prod build

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

