### PR TITLE
Fix autocomplete width issue

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -19,7 +19,7 @@
     <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="showResults"
       [cdkConnectedOverlayDisableClose]="true" [cdkConnectedOverlayMinWidth]="input.offsetWidth">
       <ul #resultsList [attr.id]="configuration.id + '-listbox'" role="listbox" class="usa-list 
-        usa-list--unstyled" (scroll)="onScroll()">
+        usa-list--unstyled sds-autocomplete" (scroll)="onScroll()">
         <ng-container *ngIf="results && results.length">
           <li [attr.id]="configuration.id + '-resultItem-' + i" role="option" [ngClass]="{
               'sds-autocomplete__group': configuration.isGroupingEnabled,

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -19,7 +19,7 @@
     <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="showResults"
       [cdkConnectedOverlayDisableClose]="true" [cdkConnectedOverlayMinWidth]="input.offsetWidth">
       <ul #resultsList [attr.id]="configuration.id + '-listbox'" role="listbox" class="usa-list 
-        usa-list--unstyled sds-autocomplete" (scroll)="onScroll()">
+        usa-list--unstyled" (scroll)="onScroll()">
         <ng-container *ngIf="results && results.length">
           <li [attr.id]="configuration.id + '-resultItem-' + i" role="option" [ngClass]="{
               'sds-autocomplete__group': configuration.isGroupingEnabled,

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -17,7 +17,7 @@
         " autocomplete="off" />
     </div>
     <ng-template cdkConnectedOverlay [cdkConnectedOverlayOrigin]="trigger" [cdkConnectedOverlayOpen]="showResults"
-      [cdkConnectedOverlayDisableClose]="true">
+      [cdkConnectedOverlayDisableClose]="true" [cdkConnectedOverlayMinWidth]="input.offsetWidth">
       <ul #resultsList [attr.id]="configuration.id + '-listbox'" role="listbox" class="usa-list 
         usa-list--unstyled sds-autocomplete" (scroll)="onScroll()">
         <ng-container *ngIf="results && results.length">

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
@@ -123,8 +123,3 @@
 input::-ms-clear {
   display: none;
 }
-
-.sds-autocomplete {
-  position: relative;
-  min-width: 30rem;
-}

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.spec.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.spec.ts
@@ -80,7 +80,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(1);
     const emptyItem = fixture.debugElement.query(By.css('.emptyResults'));
     expect(emptyItem).toBeTruthy();
@@ -98,7 +98,6 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
   }));
 
   it('Should have results with input and free text search on', fakeAsync(() => {
@@ -128,7 +127,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(2);
     component.onScroll();
     tick();
@@ -147,7 +146,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(1);
     expect(component.highlightedIndex).toBe(-1);
   }));
@@ -163,7 +162,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list).toBe(null);
   }));
 
@@ -172,7 +171,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
   }));
@@ -183,7 +182,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list).toBeNull();
   }));
 
@@ -200,7 +199,7 @@ describe('SamAutocompleteComponent', () => {
     component.onKeydown(downEvent);
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     const items = component.getFlatElements();
     expect(list.nativeElement.children.length).toBe(16);
     expect(items[1]['highlighted']).toBeTruthy();
@@ -305,7 +304,7 @@ describe('SamAutocompleteComponent', () => {
     component.inputFocusHandler();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     const items = component.getFlatElements();
     expect(items[0]['highlighted']).toBeTruthy();
@@ -325,7 +324,7 @@ describe('SamAutocompleteComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
     fixture.detectChanges();
@@ -353,7 +352,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(1);
   }));
 
@@ -361,7 +360,7 @@ describe('SamAutocompleteComponent', () => {
     component.inputFocusHandler();
     tick();
     fixture.detectChanges();
-    const listBefore = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const listBefore = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(listBefore.nativeElement.children.length).toBe(16);
     const event = {
       key: 'Escape',
@@ -372,7 +371,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const listAfter = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const listAfter = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(listAfter).toBeFalsy();
   }));
 
@@ -381,7 +380,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
   }));
@@ -391,7 +390,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
     const event = {
@@ -412,7 +411,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     const event = {
       key: 'Enter',
       target: { value: 'id' },
@@ -432,13 +431,13 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(list.nativeElement.children.length).toBe(16);
     component.clearInput();
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const listAfter = fixture.debugElement.query(By.css('.sds-autocomplete'));
+    const listAfter = fixture.debugElement.query(By.css('#autoId-listbox'));
     expect(listAfter).toBeFalsy();
   }));
 

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.spec.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.spec.ts
@@ -80,7 +80,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(1);
     const emptyItem = fixture.debugElement.query(By.css('.emptyResults'));
     expect(emptyItem).toBeTruthy();
@@ -98,6 +98,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
   }));
 
   it('Should have results with input and free text search on', fakeAsync(() => {
@@ -127,7 +128,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(2);
     component.onScroll();
     tick();
@@ -146,7 +147,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(1);
     expect(component.highlightedIndex).toBe(-1);
   }));
@@ -162,7 +163,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list).toBe(null);
   }));
 
@@ -171,7 +172,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
   }));
@@ -182,7 +183,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list).toBeNull();
   }));
 
@@ -199,7 +200,7 @@ describe('SamAutocompleteComponent', () => {
     component.onKeydown(downEvent);
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     const items = component.getFlatElements();
     expect(list.nativeElement.children.length).toBe(16);
     expect(items[1]['highlighted']).toBeTruthy();
@@ -304,7 +305,7 @@ describe('SamAutocompleteComponent', () => {
     component.inputFocusHandler();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     const items = component.getFlatElements();
     expect(items[0]['highlighted']).toBeTruthy();
@@ -324,7 +325,7 @@ describe('SamAutocompleteComponent', () => {
     tick();
     fixture.detectChanges();
 
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
     fixture.detectChanges();
@@ -352,7 +353,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(1);
   }));
 
@@ -360,7 +361,7 @@ describe('SamAutocompleteComponent', () => {
     component.inputFocusHandler();
     tick();
     fixture.detectChanges();
-    const listBefore = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const listBefore = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(listBefore.nativeElement.children.length).toBe(16);
     const event = {
       key: 'Escape',
@@ -371,7 +372,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const listAfter = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const listAfter = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(listAfter).toBeFalsy();
   }));
 
@@ -380,7 +381,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
   }));
@@ -390,7 +391,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     expect(component.results[0]['highlighted']).toBeTruthy();
     const event = {
@@ -411,7 +412,7 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     const event = {
       key: 'Enter',
       target: { value: 'id' },
@@ -431,13 +432,13 @@ describe('SamAutocompleteComponent', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const list = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const list = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(list.nativeElement.children.length).toBe(16);
     component.clearInput();
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-    const listAfter = fixture.debugElement.query(By.css('#autoId-listbox'));
+    const listAfter = fixture.debugElement.query(By.css('.sds-autocomplete'));
     expect(listAfter).toBeFalsy();
   }));
 


### PR DESCRIPTION
## Description
Adjust autocomplete overlay's min width to be same as input field's min width. Remove fixed restriction of min-width: 30rem for autocomplete results.

## Motivation and Context
Resolves issue where if the input width is less than 30rem, the result list would still be 30 rem rather than the same width as the autocomplete input field

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

