### PR TITLE
Accordion icon fixes for sds-filters

### DIFF
--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.html
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.html
@@ -3,9 +3,9 @@
         <mat-expansion-panel [(expanded)]="accordionItem.expanded" [disabled]="accordionItem.disabled">
             <mat-expansion-panel-header [collapsedHeight]="collapsedHeight" [expandedHeight]="expandedHeight">
                 <mat-panel-title>
+                    <span class="sds-expansion-indicator" [ngClass]="{'sds-expansion-indicator--expanded' : accordionItem.expanded}"></span>
                     <ng-container *ngTemplateOutlet="accordionItem.itemTitleTemplate"></ng-container>
                 </mat-panel-title>
-                <span class="sds-expansion-indicator" [ngClass]="{'sds-expansion-indicator--expanded' : accordionItem.expanded}"></span>
             </mat-expansion-panel-header>
             <span [ngClass]="{'display-none': !accordionItem.expanded}">
                 <ng-container *ngTemplateOutlet="accordionItem.itemContentTemplate"></ng-container>

--- a/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
+++ b/libs/packages/sam-material-extensions/src/lib/accordion/accordion.component.scss
@@ -111,12 +111,18 @@
                 font-size: 0.87rem !important;
             }
         }
+        mat-panel-title {
+            flex-direction: row-reverse;
+        }
+
         sds-accordion-title {
             font-weight: normal;
             font-size: 0.87rem;
+            margin-right: auto;
         }
         .sds-expansion-indicator {
             position: relative;
+            margin: 0;
             &::after {
                 background: none;
                 border-style: solid;
@@ -131,6 +137,7 @@
                 vertical-align: top;
                 width: 0.5em;
                 transition: transform .2s ease-in;
+                border-radius: 0;
             }
             &::before {
                 content: none !important;
@@ -149,6 +156,7 @@
                 vertical-align: top;
                 width: 0.5em;
                 transition: transform .2s ease-in;
+                border-radius: 0;
             }
             &.sds-expansion-indicator--expanded::before {
                 content: none !important;
@@ -170,42 +178,43 @@
 
 .sds-expansion-indicator {
     position: relative;
+    margin-right: 40px;
     &::after {
         content: '';
         display: inline-block;
         position: absolute;
-        right: 8px;
         width: 25px;
         height: 25px;
-        background: linear-gradient(#0a3466, #0a3466);
+        background: linear-gradient(#0a3466, #0a3466), #e2e2e2;
         background-position: center;
         background-size: 54% 1px;
         background-repeat: no-repeat;
+        border-radius: 50%;
     }
     &::before {
         content: '';
         display: inline-block;
         position: absolute;
-        right: 8px;
         width: 25px;
         height: 25px;
-        background: linear-gradient(#0a3466, #0a3466), #e2e2e2;
+        background: linear-gradient(#0a3466, #0a3466);
         background-position: center;
         background-size: 1px 54%;
         background-repeat: no-repeat;
         border-radius: 50%;
+        z-index: 1;
     }
     &.sds-expansion-indicator--expanded::after {
         content: '';
         display: inline-block;
         position: absolute;
-        right: 8px;
         width: 25px;
         height: 25px;
-        background: linear-gradient(#0a3466, #0a3466);
+        background: linear-gradient(#0a3466, #0a3466), #e2e2e2;
         background-position: center;
         background-size: 54% 1px;
         background-repeat: no-repeat;
+        border-radius: 50%;
     }
     &.sds-expansion-indicator--expanded::before {
         content: none;


### PR DESCRIPTION
## Description
Update accordion styles such that expansion icon is on left side
Update accordion styles for accordion group such that the expansion icon remains on right side

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

