### PR TITLE
Remove usa-accordion styling on top banner

### DIFF
--- a/libs/packages/components/src/lib/top-banner/top-banner.component.html
+++ b/libs/packages/components/src/lib/top-banner/top-banner.component.html
@@ -1,5 +1,4 @@
 <div class="usa-banner">
-  <div class="usa-accordion">
     <header
       class="usa-banner__header"
       [class.sam-banner__header--expanded]="showDetail"
@@ -17,7 +16,7 @@
           </p>
         </div>
         <button
-          class="usa-accordion__button usa-banner__button"
+          class="usa-banner__button"
           (click)="toggleDetails()"
           (blur)="closeDetail()"
           [attr.aria-expanded]="showDetail"
@@ -31,7 +30,7 @@
       </div>
     </header>
     <div
-      class="usa-banner__content usa-accordion__content"
+      class="usa-banner__content"
       id="gov-banner"
       [hidden]="!showDetail"
     >
@@ -60,5 +59,4 @@
         </div>
       </div>
     </div>
-  </div>
 </div>


### PR DESCRIPTION
## Description
Remove styling of usa-accordion class for banner header

## Motivation and Context
Reported by Brandy after updating to sam-styles 0.0.122. That changes to accordion css in that version caused the top banner button to be displayed incorrectly.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="961" alt="Screen Shot 2021-10-19 at 3 03 02 PM" src="https://user-images.githubusercontent.com/73653244/137974472-7b482d83-7989-4257-a47e-acfc4450ca2b.png">

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

