### PR TITLE
Stepper updates

### DIFF
--- a/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.html
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.html
@@ -1,11 +1,9 @@
 <button class="usa-button margin-bottom-3" (click)="toggleLinearMode()">Toggle Linear Mode</button>
 
-<div *ngIf="reinitializeComponents"></div>
 <custom-stepper-demo #stepper [queryParamKey]="'sdsAdvancedStepper'" [model]="model"
   [stepValidityMap]="stepValidityMap" (stepChange)="onStepChange($event)"
   [linear]="linear"
   (saveData)="onSaveData($event)"
-  *ngIf="!reinitializeComponents"
 >
 
   <sds-step id="welcome" text="Welcome" 

--- a/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.ts
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/advanced/stepper-advanced.component.ts
@@ -79,14 +79,5 @@ export class StepperAdvancedDemoComponent {
 
   toggleLinearMode() {
     this.linear = !this.linear;
-    this.reinitializeComponents = true;
-    this.model = {
-      subawardee: []
-    };
-    this.stepValidityMap = {};
-
-    setTimeout(() => {
-      this.reinitializeComponents = false;
-    }, 200)
   }
 }

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
@@ -29,14 +29,25 @@ export class SdsStepperNextDirective {
     const flatSteps = this._stepper.flatSteps;
     const nextIndex = this._stepper.selectedStepIndex + 1;
 
+    // Handle edge case - no steps or no selected step
     if (!flatSteps || this._stepper.selectedStepIndex == undefined) {
       return true;
     }
 
+    /** Handle case where current step is last step */
     if (this._stepper.selectedStepIndex >= flatSteps.length - 1) {
       return true;
     }
 
+    /** 
+    * For linear mode, enable the next step, on click, current step will be validated,
+    * and if valid, user will automatically progress to next step
+    */
+    if (this._stepper.linear) {
+      return;
+    }
+    
+    /** Otherwise, if next step is disabled or next step is review step and review step is disabled, disable next step */
     if (flatSteps[nextIndex].disabled || (flatSteps[nextIndex].isReview && this._stepper._isReviewAndSubmitDisabled)) {
       return true;
     }


### PR DESCRIPTION
## Description
Updates to stepper component:
 Updates behavior of the next button to always be enabled in linear mode. Clicking next on an invalid step with defined 
 inputs will trigger validation for that step and display validation errors

 Updates toggling of linear mode to be more dynamic. Watch for change to linear input and update step configs 
 automatically

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

