### PR TITLE
Resolve usa-accordion issues with sds-filters

### DIFF
--- a/libs/documentation/src/lib/pages/layout/filter.service.ts
+++ b/libs/documentation/src/lib/pages/layout/filter.service.ts
@@ -170,7 +170,7 @@ export class FilterService {
     },
     {
       key: 'purposeOfRegistration',
-
+      hide: true,
       type: 'multicheckbox',
       templateOptions: {
         label: 'Purpose of Registration',

--- a/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
+++ b/libs/documentation/src/lib/pages/layout/layout-responsive/layout-responsive.component.html
@@ -60,7 +60,8 @@
               <div class="sds-card__action sds-card__collapse"></div>
             </div>
             <div class="sds-card__body sds-card__body--accent-cool" id="filtersBody">
-              <sds-filters #filters [options]="filterPanelConfig.options"
+              <sds-filters #filters [options]="filterPanelConfig.options" 
+                [defaultModel]="{status: {registrationStatus: {Active: true}}}"
                 [advancedFilters]="filterPanelConfig.advancedFilters" [form]="filterPanelConfig.form"
                 [fields]="filterPanelConfig.fields" [model]="filterPanelConfig.model"
                 (filterChange)="filterChange$.next($event)">

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -9,7 +9,7 @@
       </sds-advanced-filters>
     </div>
     <div class="grid-col text-right">
-      <sds-formly-reset [options]="options" [defaultModel]="defaultModel" (resetClicked)="resetClicked.emit()"></sds-formly-reset>
+      <sds-formly-reset [options]="options" [defaultModel]="defaultModel" (resetClicked)="onResetClicked()"></sds-formly-reset>
     </div>
   </div>
 </div>

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -24,6 +24,7 @@ import { FormlyUtilsService, ReadonlyDataType } from '../formly/services/formly-
 import { SdsFormlyTypes } from '../formly/models/formly-types';
 import { SdsDialogRef, SdsDialogService, SDS_DIALOG_DATA } from '@gsa-sam/components';
 import { cloneDeep } from 'lodash-es';
+import { FormlyValueChangeEvent } from '@ngx-formly/core/lib/components/formly.field.config';
 @Component({
   selector: 'sds-filters',
   templateUrl: './sds-filters.component.html',
@@ -174,9 +175,10 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
             setTimeout(() => {
               this.form.patchValue(updatedFormValue);
             });
+            this.checkForHide();
           }
         });
-      this.cdr.detectChanges();
+        this.cdr.detectChanges();
     }
   }
 
@@ -249,6 +251,18 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   onModelChange(change: any) {
     this.updateChange(change);
   }
+
+  onResetClicked() {
+    const fieldChangeEvent: FormlyValueChangeEvent = {
+      field: undefined,
+      type: 'resetAll',
+      value: undefined
+    };
+
+    this.options.fieldChanges.next(fieldChangeEvent);
+    this.resetClicked.emit();
+  }
+
   updateChange(change) {
     const updatedModel = this.getCleanModel
       ? this.convertToModel(change)


### PR DESCRIPTION
## Description
Added logic to perform an additional hide check whenever layouts fires filter change

Update the way group wrapper opens and closes accordion. On initialization, accordions with defined models are opened. Then we listen for resetAll event and close accordions with empty model when the reset button is clicked. Sds Filters is given responsibility of emitting the resetAll event when reset all is clicked

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

