### PR TITLE
Treat label inputs as base html for checkbox and radios

### DIFF
--- a/libs/documentation/src/lib/components/formly-multicheckbox/demos/basic/multicheckbox-basic.component.ts
+++ b/libs/documentation/src/lib/components/formly-multicheckbox/demos/basic/multicheckbox-basic.component.ts
@@ -23,11 +23,12 @@ export class MultiCheckboxBasic {
         options: [
           {
             key: 'vet',
-            value: 'Veteran Owned'
+            value: 'Veteran Owned',
+            tagText: 'Tag'
           },
           {
             key: 'women',
-            value: 'Women Owned'
+            value: 'Women Owned (<a href="javascript:void(0)">HTML content for label</a>)',
           },
           {
             key: 'minority',

--- a/libs/packages/sam-formly/src/lib/formly/types/checkbox.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/checkbox.ts
@@ -14,7 +14,7 @@ import { FieldType } from '@ngx-formly/core';
         [formControl]="formControl"
         [formlyAttributes]="field" >
       <label  class="usa-checkbox__label" [for]="id">
-        {{ to.label }}
+        <span [innerHtml]="to.label"></span>
         <span *ngIf="!to.required && !to.hideOptional"> (Optional)</span>
       </label>
     </div>

--- a/libs/packages/sam-formly/src/lib/formly/types/multicheckbox.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/multicheckbox.html
@@ -5,7 +5,8 @@
       <div>
         <input [id]="id + '_Select'" type="checkbox" class="usa-checkbox__input" value="value" [checked]="allComplete"
           [attr.aria-checked]="ariaChecked" (change)="setAll($event)" />
-        <label class="usa-checkbox__label" [attr.aria-checked]="ariaChecked" [for]="id + '_Select'">{{ to.label }}
+        <label class="usa-checkbox__label" [attr.aria-checked]="ariaChecked" [for]="id + '_Select'">
+          <span [innerHtml]="to.label"></span>
         </label>
 
       </div>
@@ -44,11 +45,11 @@
                 [ngClass]="to.options[i].tagClass ? to.options[i].tagClass : 'sds-tag--info-white'">
                 {{to.options[i].tagText}}
               </span>
-              {{ option.label }}
+              <span [innerHtml]="option.label"></span>
             </label>
           </div>
 
-          <div *ngIf="to.options[i].tooltipText">
+          <div *ngIf="to.options[i].tooltipText" class="margin-top-1 margin-left-1">
             <p #tipContent [ngClass]="to.options[i].tooltipClass" class="margin-1"
               [innerHTML]="to.options[i].tooltipText"></p>
             <usa-icon [position]="to.options[i].tooltipPosition ? to.options[i].tooltipPosition :'right'"

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -10,11 +10,11 @@
           [formControl]="formControl" [value]="option.value">
 
         <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
-          {{ option.label }}
+          <span [innerHtml]="option.label"></span>
           <!-- Go through templateoptions' option because formlySelectOptions pipe will include only limited fields -->
           <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
             <div class="usa-checkbox__label-description">
-              <span class="display-block" *ngFor="let description of to.options[i].description">{{description}}</span>
+              <span class="display-block" *ngFor="let description of to.options[i].description" [innerHtml]="description"></span>
             </div>
           </ng-container>
         </label>


### PR DESCRIPTION
## Description
Update how we add labels to templates for checkboxes and radios. Use innerHTML rather than string interpolation binding to allow custom template for labels - such as anchor tags

## Motivation and Context
#868 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

