### PR TITLE
Update tree table to allow max children limit

### DIFF
--- a/libs/documentation/src/lib/components/tree-table/demos/basic/tree-table-basic.component.html
+++ b/libs/documentation/src/lib/components/tree-table/demos/basic/tree-table-basic.component.html
@@ -3,7 +3,8 @@
 <button class="usa-button usa-button--unstyled margin-right-3" (click)="expandChild()">Expand Child</button>
 <button class="usa-button usa-button--unstyled margin-right-3" (click)="collapseRow()">Collapse Row</button>
 
-<sds-tree-table #treeTable [dataSource]="displayedData" [displayColumns]="tableColumns" (viewAll)="onViewAll($event)">
+<sds-tree-table #treeTable [dataSource]="displayedData" [displayColumns]="tableColumns" (viewAll)="onViewAll($event)" 
+  [childrenLimit]="10" [numChildrenToDisplay]="5">
   <ng-container *sdsTreeTableRow="let row">
     <td>
       <h4>

--- a/libs/documentation/src/lib/components/tree-table/demos/basic/tree-table-basic.component.ts
+++ b/libs/documentation/src/lib/components/tree-table/demos/basic/tree-table-basic.component.ts
@@ -186,150 +186,126 @@ export class TreeTableBasicComponent {
           id: 'row2'
         },
         {
-          title: 'Declaration of Sentiments',
-          description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-          year: 1848,
-          id: 'row3',
-          totalChildren: 42,
-          children: [
-            {
-              title: 'Declaration of Sentiments',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row4',
-            },
-            {
-              title: 'Declaration of Sentiments',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row5',
-            },
-            {
-              title: 'Declaration of Sentiments',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row6',
-            },
-            {
-              title: 'Declaration of Sentiments',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row7',
-            },
-            {
-              title: 'Declaration of Sentiments2',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row8',
-            },
-          ]
-        },
-        {
           title: 'Emancipation Proclamation',
           description: 'An executive order granting freedom to slaves in designated southern states.',
           year: 1863,
           id: 'row9',
-          children: [
-            {
-              title: 'Bill of Rights',
-              description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-              year: 1791,
-              id: 'row2'
-            },
-            {
-              title: 'Declaration of Sentiments',
-              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-              year: 1848,
-              id: 'row10',
-              children: [
-                {
-                  title: 'Bill of Rights',
-                  description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                  year: 1791,
-                  id: 'row2'
-                },
-                {
-                  title: 'Emancipation Proclamation',
-                  description: 'An executive order granting freedom to slaves in designated southern states.',
-                  year: 1863,
-                  id: 'row9',
-                  children: [
-                    {
-                      title: 'Bill of Rights',
-                      description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                      year: 1791,
-                      id: 'row2'
-                    },
-                    {
-                      title: 'Declaration of Sentiments',
-                      description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-                      year: 1848,
-                      id: 'row10',
-                      children: [
-                        {
-                          title: 'Bill of Rights',
-                          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                          year: 1791,
-                          id: 'row2'
-                        },
-                        {
-                          title: 'Emancipation Proclamation',
-                          description: 'An executive order granting freedom to slaves in designated southern states.',
-                          year: 1863,
-                          id: 'row9',
-                          children: [
-                            {
-                              title: 'Bill of Rights',
-                              description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                              year: 1791,
-                              id: 'row2'
-                            },
-                            {
-                              title: 'Declaration of Sentiments',
-                              description: 'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
-                              year: 1848,
-                              id: 'row10',
-                            },
-                          ]
-                        },
-                        {
-                          title: 'Bill of Rights',
-                          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                          year: 1791,
-                          id: 'row2'
-                        },
-                      ]
-                    },
-                    {
-                      title: 'Bill of Rights',
-                      description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                      year: 1791,
-                      id: 'row2'
-                    },
-                  ]
-                },
-                {
-                  title: 'Bill of Rights',
-                  description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-                  year: 1791,
-                  id: 'row2'
-                },
-              ]
-              
-            },
-            {
-              title: 'Bill of Rights',
-              description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
-              year: 1791,
-              id: 'row2'
-            },
-          ]
         },
         {
           title: 'Bill of Rights',
           description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
           year: 1791,
           id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+      ]
+    },
+    {
+      description: 'Statement adopted by the Continental Congress declaring independence from the British Empire.',
+      title: 'Declaration of Independence',
+      year: 1776,
+      id: 'row1',
+      children: [
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
+        },
+        {
+          title: 'Bill of Rights',
+          description: 'The first ten amendments of the U.S. Constitution guaranteeing rights and freedoms.',
+          year: 1791,
+          id: 'row2'
+        },
+        {
+          title: 'Emancipation Proclamation',
+          description: 'An executive order granting freedom to slaves in designated southern states.',
+          year: 1863,
+          id: 'row9',
         },
       ]
     },

--- a/libs/packages/components/src/lib/tree-table/tree-table.component.html
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.html
@@ -15,6 +15,7 @@
   </table>
 </div>
 
+<!-- TODO: Extract this into separate component -->
 <ng-template #treeTablePanel 
   let-row="row" 
   let-level="level" 
@@ -38,7 +39,8 @@
     [ngClass]="{'sds-tree-table__row--selected': row === _selectedRow, 'sds-tree-table__row--highlight-border': parentSelected}"
     >
     <td>
-      <span *ngIf="rows && index == rows.length" #border class="vertical-border">
+      <span *ngIf="displayVerticalBorder(parent, index - 1, rows)" 
+        #border class="vertical-border">
         <!-- Programitcally set height of vertical border because we won't know the height until view finishes rendering -->
         {{setHeight(tableRow, parentRow, border)}}
       </span>
@@ -58,20 +60,33 @@
   </tr>
 
   <ng-container *ngIf="row.expanded">
-    <ng-container *ngFor="let data of row.children; index as i" 
-    [ngTemplateOutlet]="treeTablePanel" 
-    [ngTemplateOutletContext]="getTemplateContext(row, data, i, level, parentSelected, tableRow)">
-    </ng-container>
+    <ng-container *ngFor="let data of row.children; index as i">
+      <ng-container 
+        *ngIf="row.children.length <= childrenLimit || 
+          row.viewAllChildren || 
+          i  < numChildrenToDisplay"
+        [ngTemplateOutlet]="treeTablePanel" 
+        [ngTemplateOutletContext]="getTemplateContext(row, data, i, level, parentSelected, tableRow)">
+      </ng-container>
+    </ng-container> 
   </ng-container>
-
 
   <tr class="text-center" 
     #viewAllRow
-    *ngIf="row.expanded && row.totalChildren > row.children.length" 
+    *ngIf="row.expanded && !row.viewAllChildren && (row.totalChildren > row.children.length || row.children.length > childrenLimit)" 
     (keydown.enter)="viewAllClicked(row, viewAllRow, tableRow)"
     (keydown)="onKeyDown($event, viewAllRow)"
   >
     <td></td>
-    <td class="width-100"><button class="usa-button usa-button--base" (click)="viewAllClicked(row, viewAllRow, tableRow)">View All ({{row.totalChildren - row.children.length}})</button></td>
+    <td class="width-100">
+      <button class="usa-button usa-button--base" (click)="viewAllClicked(row, viewAllRow, tableRow)">
+        View All ( 
+          <span *ngIf="row.totalChildren && row.totalChildren > row.children.length; else childrenLength">
+            {{row.totalChildren}}
+          </span>
+        )
+          <ng-template #childrenLength>{{row.children.length}}</ng-template>
+      </button>
+    </td>
   </tr>
 </ng-template>


### PR DESCRIPTION
## Description
Update truncation options for children in tree - Adds an option for max limit on number of children to display and another input config that defines how many children to display if we're over that max.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

