### PR TITLE
Update expansion behavior for tree table

### DIFF
--- a/libs/packages/components/src/lib/tree-table/tree-table.component.html
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.html
@@ -45,7 +45,7 @@
         {{setHeight(tableRow, parentRow, border)}}
       </span>
       <span class="horizontal-border"></span>
-      <button class="usa-button sds-button--circle border-0 bg-white" *ngIf="row.children"
+      <button class="usa-button sds-button--circle border-0 bg-white" *ngIf="row.children || row.totalChildren > 0"
         [attr.tabindex]="row === _selectedRow ? 1 : -1" (click)="onRowClicked(row, tableRow)">
         <span class="usa-sr-only">Expand / Collapse current row</span>
         <usa-icon 
@@ -73,7 +73,7 @@
 
   <tr class="text-center" 
     #viewAllRow
-    *ngIf="row.expanded && !row.viewAllChildren && (row.totalChildren > row.children.length || row.children.length > childrenLimit)" 
+    *ngIf="row.expanded && !row.viewAllChildren && (row.totalChildren > row.children?.length || row.children?.length > childrenLimit)" 
     (keydown.enter)="viewAllClicked(row, viewAllRow, tableRow)"
     (keydown)="onKeyDown($event, viewAllRow)"
   >
@@ -81,11 +81,11 @@
     <td class="width-100">
       <button class="usa-button usa-button--base" (click)="viewAllClicked(row, viewAllRow, tableRow)">
         View All ( 
-          <span *ngIf="row.totalChildren && row.totalChildren > row.children.length; else childrenLength">
+          <span *ngIf="row.totalChildren && row.totalChildren > row.children?.length; else childrenLength">
             {{row.totalChildren}}
           </span>
         )
-          <ng-template #childrenLength>{{row.children.length}}</ng-template>
+          <ng-template #childrenLength>{{row.children?.length}}</ng-template>
       </button>
     </td>
   </tr>

--- a/libs/packages/components/src/lib/tree-table/tree-table.component.ts
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.ts
@@ -69,7 +69,7 @@ export class SdsTreeTableComponent {
 
   constructor(
     private elementRef: ElementRef,
-    private cdr: ChangeDetectorRef,
+    public cdr: ChangeDetectorRef,
     private ngZone: NgZone,
   ) {}
 
@@ -238,7 +238,7 @@ export class SdsTreeTableComponent {
   }
 
   onRowClicked(row: SdsTreeTableData, tableRow: HTMLTableRowElement) {
-    if (row.children) {
+    if (row.children || row.totalChildren > 0) {
       row.expanded = !row.expanded;
     }
 


### PR DESCRIPTION
## Description
Update expansion behavior for tree table such that if totalChildren of a row is greater than 0, we show the expansion indicator. Previously, we were only considering the length of row's children before showing expansion indicator, however, in the event that users want to lazy load children entirely until expansion is clicked, this children would be null while totalChildren value would be non-zero.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

