### PR TITLE
Reset View All for tree table rows on collapse

### DIFF
--- a/libs/packages/components/src/lib/tree-table/tree-table.component.ts
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.ts
@@ -131,6 +131,10 @@ export class SdsTreeTableComponent {
       if (data.children) {
         this.toggleAllHelper(data.children, expanded);
         data.expanded = expanded;
+
+        if (!expanded) {
+          data.viewAllChildren = false;
+        }
       }
     });
   }
@@ -166,6 +170,7 @@ export class SdsTreeTableComponent {
 
   private collapseRowHelper(row: any) {
     row.expanded = false;
+    row.viewAllChildren = false;
     if (row.children) {
       row.children.forEach(child => this.collapseRowHelper(child));
     }
@@ -240,6 +245,10 @@ export class SdsTreeTableComponent {
   onRowClicked(row: SdsTreeTableData, tableRow: HTMLTableRowElement) {
     if (row.children || row.totalChildren > 0) {
       row.expanded = !row.expanded;
+    }
+
+    if (!row.expanded) {
+      row.viewAllChildren = false;
     }
 
     this._selectedRow = row;


### PR DESCRIPTION
## Description
Once a table row is collapsed, the `viewAllChildren` state resets to false. This state is used to define whether user has clicked on 'View All' for a tree table row. This change effectively allows a way for users to hide children that were displayed by clicking on 'View All' button

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

