### PR TITLE
Adjust bottom value of vertical border in tree table based on row height

### DIFF
--- a/libs/packages/components/src/lib/tree-table/tree-table.component.ts
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.ts
@@ -200,12 +200,13 @@ export class SdsTreeTableComponent {
       setTimeout(() => {
         const firstRect = parentRow.getBoundingClientRect();
         const rowRect = row.getBoundingClientRect();
-    
+        
         const yFirstRect = firstRect.top + firstRect.height / 2;
         const yRowRect = rowRect.top + rowRect.height / 2;
-    
+
         const height = yRowRect - yFirstRect - 20;
         border.style.height = `${height}px`;
+        border.style.bottom = `${rowRect.height / 2}px`;
       })
     })
   }


### PR DESCRIPTION
## Description
Resolve UI isue with tree table vertical border where rendering table rows of greater height caused vertical border to be out of alignment with the horizontal ones.

## Motivation and Context
Initially brought to attention after a tree table demo done last sprint in design system parking lot

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

