### PR TITLE
Horizontal filters datepickers

### DIFF
--- a/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
@@ -58,6 +58,7 @@ export class HorizontalFilterDemo {
       templateOptions: {
         label: 'Date Range',
         group: 'popover',
+        closeOnClickOutside: false,
       },
       fieldGroup: [
         {

--- a/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
+++ b/libs/documentation/src/lib/components/filters/demos/horizontal-filter/horizontal-filter.component.ts
@@ -54,6 +54,68 @@ export class HorizontalFilterDemo {
       },
     },
     {
+      key: 'dateRange',
+      templateOptions: {
+        label: 'Date Range',
+        group: 'popover',
+      },
+      fieldGroup: [
+        {
+          key: 'dateRangeSelect',
+          type: 'select',
+          className: 'display-block',
+          templateOptions: {
+            label: 'Select Date',
+            options: [
+              {label: 'Anytime', value: 'anytime'},
+              {label: 'Past day', value: 'pastDay'},
+              {label: 'Past Week', value: 'pastWeek'},
+              {label: 'Custom Dates', value: 'customDate'}
+            ],
+            hideOptional: true,
+          }
+        },
+        {
+          key: 'createdDate',
+          type: 'datepicker',
+          className: 'display-block',
+          templateOptions: {
+            label: 'Created Date',
+            minDate: new Date(2019, 9, 5),
+            maxDate: new Date(2020, 11, 15),
+            placeholder: 'eg: ' + new Date().toLocaleString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric'
+            }),
+            hideOptional: true,
+          },
+          hideExpression: (model) => {
+            return !model || !model['dateRangeSelect'] || model['dateRangeSelect'] != 'customDate';
+          }
+        },
+        {
+          key: 'expirationDate',
+          type: 'datepicker',
+          className: 'display-block',
+          templateOptions: {
+            label: 'Expires Date',
+            minDate: new Date(2019, 9, 5),
+            maxDate: new Date(2020, 11, 15),
+            placeholder: 'eg: ' + new Date().toLocaleString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric'
+            }),
+            hideOptional: true,
+          },
+          hideExpression: (model) => {
+            return !model || !model['dateRangeSelect'] || model['dateRangeSelect'] != 'customDate';
+          }
+        }
+      ]
+    },
+    {
       key: 'expirationDateRangeEx',
       type: 'daterangepickerv2',
       hide: true,

--- a/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
+++ b/libs/packages/sam-formly/src/lib/formly/wrappers/group.wrapper.ts
@@ -52,8 +52,8 @@ import { filter } from 'rxjs/operators';
           <div
             [sdsPopover]="popoverContent"
               [position]="'bottom'"
-              [closeOnContentClick]="false"
-              [closeOnClickOutside]="true"
+              [closeOnContentClick]="to.closeOnContentClick != undefined ? to.closeOnContentClick : false"
+              [closeOnClickOutside]="to.closeOnClickOutside != undefined ? to.closeOnClickOutside : true"
               tabindex="0" [attr.aria-label]="to.label">
             {{to.label}}
             <usa-icon [icon]="'chevron-down'" [size]="'sm'"></usa-icon>


### PR DESCRIPTION
## Description
Update demo of horizontal filters to use date range with hide expression behavior
Update popover wrapper to allow template options to toggle close behavior (Auto close on external click vs closing only on the button that toggles popup)

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

