### PR TITLE
IAE-65328: Add option to pass radio option template

### DIFF
--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
@@ -27,7 +27,7 @@
       </div>
       <ng-container *ngIf="to.options[i].icon">
         <div class="radio-icon">
-          <usa-icon [icon]="to.options[i].icon" [size]="'5x'" class="icon-display-block" ngClass="to.options[i].iconClass"></usa-icon>
+          <usa-icon [icon]="to.options[i].icon" [size]="'5x'" class="icon-display-block" ngClass="{{to.options[i].iconClass}}"></usa-icon>
         </div>
       </ng-container>
     </div>

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
@@ -27,7 +27,7 @@
       </div>
       <ng-container *ngIf="to.options[i].icon">
         <div class="radio-icon">
-          <usa-icon [icon]="to.options[i].icon" [size]="'5x'"></usa-icon>
+          <usa-icon [icon]="to.options[i].icon" [size]="'5x'" class="icon-display-block" ngClass="to.options[i].iconClass"></usa-icon>
         </div>
       </ng-container>
     </div>

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.html
@@ -1,0 +1,35 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>
+
+
+<ng-template #radioTemplate let-option let-i="i" let-to="to" let-field="field" let-id="id" let-showError="showError" let-formControl="formControl">
+  <div class="sds-card icon-radio-option">
+    <div class="sds-card__body">
+      <div>
+        <input class="usa-radio__input" [ngClass]="{'usa-radio__input--tile': to.tile, 'usa-input--error': !showError}"
+          [formlyAttributes]="field" [id]="id + '_' + i" type="radio" [name]="id" checked="checked"
+          [formControl]="formControl" [value]="option.value">
+
+        <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
+          <span [innerHtml]="option.label" class="radio-label-text"></span>
+        </label>
+        <ng-container *ngIf="to.options[i].subText">
+          <ul class="sub-text-list">
+            <ng-container *ngFor="let subText of to.options[i].subText">
+              <li>{{subText}}</li>
+            </ng-container>
+          </ul>
+        </ng-container>
+        <ng-container *ngIf="to.options[i].linkText">
+          <a class="radio-link">{{to.options[i].linkText}}</a>
+        </ng-container>
+      </div>
+      <ng-container *ngIf="to.options[i].icon">
+        <div class="radio-icon">
+          <usa-icon [icon]="to.options[i].icon" [size]="'5x'"></usa-icon>
+        </div>
+      </ng-container>
+    </div>
+  </div>
+</ng-template>

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.scss
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.scss
@@ -1,0 +1,24 @@
+.icon-radio-option{
+  border-radius: 1.25rem;
+  margin-bottom: 3rem;
+  .sds-card__body{
+    display: flex;
+    justify-content: space-between;
+    .radio-label-text{
+      padding-left: 2rem;
+    }
+    .sub-text-list{
+      margin-left: 2.3rem
+    }
+    .radio-link{
+      margin-left: 3.8rem;
+    }
+    .radio-icon{
+      margin-right: 4rem;
+      display: flex;
+      align-items: center;
+    }
+
+  }
+
+}

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.scss
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.scss
@@ -8,7 +8,7 @@
       padding-left: 2rem;
     }
     .sub-text-list{
-      margin-left: 2.3rem
+      margin-left: 3.2rem
     }
     .radio-link{
       margin-left: 3.8rem;

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.ts
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.ts
@@ -1,0 +1,77 @@
+import { AfterViewInit, Component, TemplateRef, ViewChild } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
+
+@Component({
+  selector: 'gsa-sam-radio-template',
+  templateUrl: './radio-template.component.html',
+  styleUrls: ['./radio-template.component.scss']
+})
+export class RadioTemplateComponent implements AfterViewInit{
+
+  @ViewChild('radioTemplate') radioTemplate : TemplateRef<any>
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'entity.taxFilingStatus',
+      type: 'radio',
+
+      templateOptions: {
+        required: true,
+        options: [
+          {
+            key: 'ccorp',
+            value: 'Register for Financial Assistance Awards Only ',
+            subText: [
+              'To apply for grants and loans as described by 2 CFR 200.',
+              'Includes getting a unique entity ID and entity registration.'
+            ],
+            linkText: 'What do I need for registration?',
+            icon: 'uswds-attach-money'
+          },
+          {
+            key: 'nonprofit',
+            value: 'Register for All Awards',
+            subText: [
+              'To bid on federal contracts and other procurements, as described by the Federal Acquisition Regulation (FAR).',
+              'To apply for grants and loans as described by 2 CFR 200.'
+            ],
+            linkText: 'What do I need for registration?',
+            icon: 'award'
+          },
+          {
+            key: 'partnerllc',
+            value: 'Get a Unique Entity ID Only',
+            subText: [
+              'May be required to report subawards, such as federal subcontractors or sub-grants.',
+              'You will get a unique entity ID. This is NOT an entity registration.',
+            ],
+            linkText: 'What\'s the difference between getting a UEI only and registration',
+            icon: 'uswds-identification'
+          }
+        ],
+      },
+      modelOptions: {
+        updateOn: 'blur',
+      },
+      lifecycle: {
+        onChanges: function (form, field) {
+          field.formControl.valueChanges.subscribe((v) => {
+            console.log(form['controls']['entity']);
+          });
+        },
+      },
+    },
+  ];
+
+  onModelChange($event) {
+    console.log($event);
+  }
+  ngAfterViewInit(){
+    this.fields[0].templateOptions.template = this.radioTemplate;
+
+  }
+}

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.ts
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.component.ts
@@ -30,7 +30,7 @@ export class RadioTemplateComponent implements AfterViewInit{
               'Includes getting a unique entity ID and entity registration.'
             ],
             linkText: 'What do I need for registration?',
-            icon: 'uswds-attach-money'
+            icon: 'uswds-attach-money',
           },
           {
             key: 'nonprofit',
@@ -40,7 +40,8 @@ export class RadioTemplateComponent implements AfterViewInit{
               'To apply for grants and loans as described by 2 CFR 200.'
             ],
             linkText: 'What do I need for registration?',
-            icon: 'award'
+            icon: 'award',
+            iconClass: 'text-secondary'
           },
           {
             key: 'partnerllc',
@@ -50,7 +51,7 @@ export class RadioTemplateComponent implements AfterViewInit{
               'You will get a unique entity ID. This is NOT an entity registration.',
             ],
             linkText: 'What\'s the difference between getting a UEI only and registration',
-            icon: 'uswds-identification'
+            icon: 'uswds-identification',
           }
         ],
       },

--- a/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.module.ts
+++ b/libs/documentation/src/lib/components/formly-radio/demos/template/radio-template.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { IconModule, uswdsAttachMoney, uswdsIdentification } from '@gsa-sam/ngx-uswds-icons';
+import { SdsFormlyModule } from "@gsa-sam/sam-formly";
+import { FormlyModule } from "@ngx-formly/core";
+import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons';
+import { RadioTemplateComponent } from "./radio-template.component";
+import { award } from 'ngx-bootstrap-icons'
+
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot(), IconModule, NgxBootstrapIconsModule.pick({uswdsAttachMoney, uswdsIdentification, award})],
+  declarations: [RadioTemplateComponent],
+  exports: [RadioTemplateComponent],
+  bootstrap: [RadioTemplateComponent]
+})
+export class RadioTemplateModule {}

--- a/libs/documentation/src/lib/components/formly-radio/radio.module.ts
+++ b/libs/documentation/src/lib/components/formly-radio/radio.module.ts
@@ -10,9 +10,18 @@ import { ComponentWrapperComponent } from '../../shared/component-wrapper/compon
 import { RadioBasicModule } from './demos/basic/radio-basic.module';
 import { RadioAdvancedComponent } from './demos/advanced/radio-advanced.component';
 import { RadioAdvancedModule } from './demos/advanced/radio-advanced.module';
+import { RadioTemplateComponent } from './demos/template/radio-template.component';
+import { RadioTemplateModule } from './demos/template/radio-template.module';
 
 declare var require: any;
 const DEMOS = {
+  template: {
+    title: 'Template Form Radio',
+    type: RadioTemplateComponent,
+    code: require('!!raw-loader!./demos/template/radio-template.component'),
+    markup: require('!!raw-loader!./demos/template/radio-template.component.html'),
+    path: 'libs/documentation/src/lib/components/formly-radio/demos/template'
+  },
   basic: {
     title: 'Basic Form Radio',
     type: RadioBasic,
@@ -59,6 +68,7 @@ export const ROUTES = [
     DocumentationComponentsSharedModule,
     RadioBasicModule,
     RadioAdvancedModule,
+    RadioTemplateModule
   ]
 })
 export class RadioModule {

--- a/libs/documentation/src/lib/components/formly-radio/radio.module.ts
+++ b/libs/documentation/src/lib/components/formly-radio/radio.module.ts
@@ -15,13 +15,6 @@ import { RadioTemplateModule } from './demos/template/radio-template.module';
 
 declare var require: any;
 const DEMOS = {
-  template: {
-    title: 'Template Form Radio',
-    type: RadioTemplateComponent,
-    code: require('!!raw-loader!./demos/template/radio-template.component'),
-    markup: require('!!raw-loader!./demos/template/radio-template.component.html'),
-    path: 'libs/documentation/src/lib/components/formly-radio/demos/template'
-  },
   basic: {
     title: 'Basic Form Radio',
     type: RadioBasic,
@@ -35,7 +28,14 @@ const DEMOS = {
     code: require('!!raw-loader!./demos/advanced/radio-advanced.component'),
     markup: require('!!raw-loader!./demos/advanced/radio-advanced.component.html'),
     path: 'libs/documentation/src/lib/components/formly-radio/demos/advanced'
-  }
+  },
+  template: {
+    title: 'Template Form Radio',
+    type: RadioTemplateComponent,
+    code: require('!!raw-loader!./demos/template/radio-template.component'),
+    markup: require('!!raw-loader!./demos/template/radio-template.component.html'),
+    path: 'libs/documentation/src/lib/components/formly-radio/demos/template'
+  },
 };
 
 export const ROUTES = [

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -2,32 +2,53 @@
   [attr.aria-describedby]="to.description ? id + '_description' : undefined">
   <ng-container *ngFor="
   let option of to.options | formlySelectOptions: field | async;
-  let i = index">
-    <div class="grid-row">
-      <div>
-        <input class="usa-radio__input" [ngClass]="{'usa-radio__input--tile': to.tile, 'usa-input--error': !showError}"
-          [formlyAttributes]="field" [id]="id + '_' + i" type="radio" [name]="id" checked="checked"
-          [formControl]="formControl" [value]="option.value">
-
-        <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
-          <span [innerHtml]="option.label"></span>
-          <!-- Go through templateoptions' option because formlySelectOptions pipe will include only limited fields -->
-          <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
-            <div class="usa-checkbox__label-description">
-              <span class="display-block" *ngFor="let description of to.options[i].description"
-                [innerHtml]="description"></span>
-            </div>
-          </ng-container>
-        </label>
-      </div>
-
-      <div *ngIf="to.options[i].tooltipText">
-        <p #tipContent [ngClass]="to.options[i].tooltipClass" class="margin-1" [innerHTML]="to.options[i].tooltipText">
-        </p>
-        <usa-icon class="padding-top-105 margin-left-1"
-          [position]="to.options[i].tooltipPosition ? to.options[i].tooltipPosition :'right'" [sdsTooltip]="tipContent"
-          [size]="'lg'" [icon]="'info-circle'"></usa-icon>
-      </div>
-    </div>
+  let i = index"
+  [ngTemplateOutlet]="(to.template ? to.template : defaultTemplate)"
+  [ngTemplateOutletContext]="{
+    $implicit: option,
+    i: i,
+    to:to,
+    field: field,
+    id: id,
+    showError: showError,
+    formControl: formControl
+  }">
   </ng-container>
 </form>
+
+<ng-template let-option let-i="i" let-to="to" #defaultTemplate>
+  <!-- <p>i: {{i}}</p> -->
+  <div class="grid-row">
+    <div>
+      <input class="usa-radio__input"
+        [ngClass]="{'usa-radio__input--tile': to.tile, 'usa-input--error': !showError}" [formlyAttributes]="field"
+        [id]="id + '_' + i" type="radio" [name]="id" checked="checked" [formControl]="formControl"
+        [value]="option.value">
+
+      <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
+        <span [innerHtml]="option.label"></span>
+        <!-- <p>i:  {{i}}</p> -->
+        <!-- <p>to:  {{to | json}}</p>
+        <p>to.options[i]: {{to.options[i] | json}}</p>
+        <p>to.options[i].description: {{to.options[i].description | json}}</p> -->
+        <!-- <span>{{}}</span> -->
+        <!-- Go through templateoptions' option because formlySelectOptions pipe will include only limited fields -->
+        <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
+          <div class="usa-checkbox__label-description">
+            <span class="display-block" *ngFor="let description of to.options[i].description"
+              [innerHtml]="description"></span>
+          </div>
+        </ng-container>
+      </label>
+    </div>
+
+    <div *ngIf="to.options[i].tooltipText">
+      <p #tipContent [ngClass]="to.options[i].tooltipClass" class="margin-1"
+        [innerHTML]="to.options[i].tooltipText">
+      </p>
+      <usa-icon class="padding-top-105 margin-left-1"
+        [position]="to.options[i].tooltipPosition ? to.options[i].tooltipPosition :'right'"
+        [sdsTooltip]="tipContent" [size]="'lg'" [icon]="'info-circle'"></usa-icon>
+    </div>
+  </div>
+</ng-template>

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -17,7 +17,6 @@
 </form>
 
 <ng-template let-option let-i="i" let-to="to" #defaultTemplate>
-  <!-- <p>i: {{i}}</p> -->
   <div class="grid-row">
     <div>
       <input class="usa-radio__input"
@@ -27,12 +26,6 @@
 
       <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
         <span [innerHtml]="option.label"></span>
-        <!-- <p>i:  {{i}}</p> -->
-        <!-- <p>to:  {{to | json}}</p>
-        <p>to.options[i]: {{to.options[i] | json}}</p>
-        <p>to.options[i].description: {{to.options[i].description | json}}</p> -->
-        <!-- <span>{{}}</span> -->
-        <!-- Go through templateoptions' option because formlySelectOptions pipe will include only limited fields -->
         <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
           <div class="usa-checkbox__label-description">
             <span class="display-block" *ngFor="let description of to.options[i].description"

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.ts
@@ -1,14 +1,24 @@
-import { Component} from '@angular/core';
+import { AfterViewInit, Component, TemplateRef, ViewChild} from '@angular/core';
 import { FieldType } from '@ngx-formly/core';
 
 @Component({
   selector: 'sds-formly-field-radio',
   templateUrl: './radio.html',
 })
-export class FormlyFieldRadioComponent extends FieldType {
+export class FormlyFieldRadioComponent extends FieldType implements AfterViewInit{
+
+  @ViewChild('defaultTemplate') defaultTemplate: TemplateRef<any>;
+  public displayedTemplate = null;
+
   defaultOptions = {
     templateOptions: {
       options: [],
     },
   };
+  ngAfterViewInit(){
+    const passedIn = this.to.template;
+    setTimeout(()=>{
+      this.displayedTemplate = passedIn ? passedIn : this.defaultTemplate;
+    })
+  }
 }


### PR DESCRIPTION
## Description
Updated formly radio template to allow developer to specify template that is rendered for each radio option.
Added demo showing how a developer might add a template in ngAfterInit method

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEDEV-65328

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

