### PR TITLE
Update demo site based on Icons block fix

### DIFF
--- a/libs/documentation/src/lib/components/icons/demos/coloring/icons-coloring.component.scss
+++ b/libs/documentation/src/lib/components/icons/demos/coloring/icons-coloring.component.scss
@@ -1,3 +1,4 @@
 usa-icon{
   padding-right: 1rem;
+  display: inline-block;
 }

--- a/libs/documentation/src/lib/components/shared/examples-page/demo.component.scss
+++ b/libs/documentation/src/lib/components/shared/examples-page/demo.component.scss
@@ -5,3 +5,7 @@
     padding: 0;
   }
 }
+
+a.usa-button--unstyled{
+  display: inline-block;
+}

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.html
@@ -157,10 +157,10 @@
     <ng-container *ngIf="!input.disabled">
       <span class="position-absolute right-105 top-1 cursor-pointer bg-white">
         <span *ngIf="isClearIconVisible()" role="button" aria-label="Clear input" (click)="clearInput()"
-          (keyup.enter)="clearInput()" tabindex="0">
+          (keyup.enter)="clearInput()" tabindex="0" class="icon-container">
           <usa-icon [icon]="'x'" size="lg" class="font-sans-xs"></usa-icon>
         </span>
-        <span *ngIf="!configuration.isTagModeEnabled" class="margin-left-1 margin-top-05">
+        <span *ngIf="!configuration.isTagModeEnabled" class="margin-left-1 margin-top-05 icon-container">
           <usa-icon role="button" aria-label="Display Options" tabindex="0" *ngIf="!showResults && !disabled"
             (click)="openOptions()" class="font-sans-xs" (keyup.enter)="openOptions()" [icon]="'caret-down-fill'"
             size="1x">

--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.scss
@@ -123,3 +123,7 @@
 input::-ms-clear {
   display: none;
 }
+
+span.icon-container{
+  display: inline-block;
+}

--- a/libs/packages/components/src/lib/search/search.component.scss
+++ b/libs/packages/components/src/lib/search/search.component.scss
@@ -23,10 +23,6 @@ input::-ms-clear {
     transition: color .2s;
   }
 
-  .search-icon {
-    top: 0px;
-  }
-
   .close-icon {
     width: 4rem;
     top: 4px;

--- a/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.scss
+++ b/libs/packages/sam-formly/src/lib/formly-reset/formly-reset.component.scss
@@ -16,3 +16,8 @@
 .icon-reset {
   font-size: 20px;
 }
+
+
+button{
+  display: inline-flex;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2046,7 +2046,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
@@ -2531,9 +2535,9 @@
       }
     },
     "@gsa-sam/ngx-uswds-icons": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@gsa-sam/ngx-uswds-icons/-/ngx-uswds-icons-0.0.7.tgz",
-      "integrity": "sha512-VZCOXD1aI4StBTdWHRPyr0vT2W3NmrCnZvL8RP0HryRpxqyucTKP/KYk5+3IW+8cYJYdY9oCQD4cYa2jSMynDg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@gsa-sam/ngx-uswds-icons/-/ngx-uswds-icons-11.0.1.tgz",
+      "integrity": "sha512-gLyy18XDeH5UKARrUF3DYilRhuyL2Aa9VpNJnE5OqYIF6Tz/FzN0/qOJoGRPy2xyYR1mb/sPeyEF+QXOcFH2nQ==",
       "requires": {
         "ngx-bootstrap-icons": "^1.5.0",
         "tslib": "^2.0.0"
@@ -3976,6 +3980,15 @@
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.18.0.tgz",
       "integrity": "sha512-PQu3Kyv9dM4FnwB7XGj1+HucW+ShvJzJqjuw1JkKVs1mWdwOKVcRjOi+pV9X52A0tNvrPCsPkbFFQb+wE1EAXw=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.1.0",
@@ -8097,6 +8110,12 @@
         "through2": "^2.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filelist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -11498,7 +11517,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -12586,6 +12609,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.25",
@@ -23735,7 +23764,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@gsa-sam/components": "11.0.16",
     "@gsa-sam/layouts": "11.0.16",
     "@gsa-sam/ngx-uswds": "0.0.18",
-    "@gsa-sam/ngx-uswds-icons": "0.0.7",
+    "@gsa-sam/ngx-uswds-icons": "^11.0.1",
     "@gsa-sam/sam-formly": "11.0.16",
     "@gsa-sam/sam-material-extensions": "11.0.16",
     "@gsa-sam/sam-styles": "0.0.128",


### PR DESCRIPTION
## Description
With the update of the display property of ngx-uswds-icons, some of our demo site and components needed to be updated to remove previous compensation for additional padding(which the display update resolves) and otherwise fix icon appearances. 

## Motivation and Context

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

