### PR TITLE
Add icon to search button

### DIFF
--- a/libs/packages/components/src/lib/search/search.component.html
+++ b/libs/packages/components/src/lib/search/search.component.html
@@ -41,6 +41,7 @@
     </span>
     <button *ngIf="!searchSettings.isSuffixSearchIcon" #buttonEl class="usa-button" type="submit"
       [attr.aria-label]="searchSettings.ariaLabel ? searchSettings.ariaLabel : 'Search'" (click)="handleClick($event)">
+      <usa-icon [icon]="'search'"></usa-icon>
     </button>
   </div>
 


### PR DESCRIPTION
## Description
Search icon was no longer showing on button in search component. This PR added a usa-icon to that button. Styling for this PR is in [sam-styles](https://github.com/GSA/sam-styles/pull/537)

## Motivation and Context
Search icon was no longer showing on button in search component.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
Before:
<img width="103" alt="Screen Shot 2022-03-30 at 6 27 50 AM" src="https://user-images.githubusercontent.com/72805180/160811686-18fd7495-893c-4889-b81c-d638fc3c7cf3.png">
After:
<img width="103" alt="Screen Shot 2022-03-30 at 6 24 11 AM" src="https://user-images.githubusercontent.com/72805180/160811683-08b1bc2b-9770-4a92-8c42-8f2efcd3e0f2.png">




## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

