### PR TITLE
Remove padding-2 class to center icons in safari

### DIFF
--- a/libs/documentation/src/lib/components/formly-stepper/demos/advanced/custom-stepper.component.html
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/advanced/custom-stepper.component.html
@@ -37,7 +37,7 @@
 
     <div class="grid-row grid-gap flex-justify-center margin-top-4">
       <div class="margin-right-1">
-        <button class="usa-button sds-button--circle usa-button--base usa-button--big padding-2" sdsStepperPrevious
+        <button class="usa-button sds-button--circle usa-button--base usa-button--big" sdsStepperPrevious
           [attr.id]="id + '-prevBtn'">
           <usa-icon [icon]="'chevron-left'"></usa-icon>
         </button>
@@ -48,7 +48,7 @@
       </div>
 
       <div class="margin-right-1">
-        <button class="usa-button sds-button--circle usa-button--big usa-button--base padding-2"
+        <button class="usa-button sds-button--circle usa-button--big usa-button--base"
           [attr.id]="id + '-closeBtn'">
           <usa-icon [icon]="'x'"></usa-icon>
         </button>
@@ -58,7 +58,7 @@
       </div>
 
       <div class="margin-right-1">
-        <button class="usa-button sds-button--circle usa-button--big usa-button--base padding-2"
+        <button class="usa-button sds-button--circle usa-button--big usa-button--base"
           [attr.id]="id + '-helpBtn'">
           <usa-icon [icon]="'question'"></usa-icon>
         </button>
@@ -68,7 +68,7 @@
       </div>
 
       <div class="margin-right-1">
-        <button class="usa-button sds-button--circle usa-button--big usa-button--base padding-2" sdsStepperSave
+        <button class="usa-button sds-button--circle usa-button--big usa-button--base" sdsStepperSave
           [attr.id]="id + '-saveBtn'">
           <usa-icon [icon]="'save'"></usa-icon>
         </button>
@@ -79,7 +79,7 @@
 
       <div class="margin-right-1">
         <button #saveAndContinueBtn
-          class="usa-button sds-button--circle usa-button--base usa-button--big usa-button--active padding-2"
+          class="usa-button sds-button--circle usa-button--base usa-button--big usa-button--active"
           sdsStepperNext [attr.id]="id + '-nextBtn'">
           <usa-icon [icon]="'chevron-right'"></usa-icon>
         </button>

--- a/libs/documentation/src/lib/components/formly-stepper/demos/uswds-stepper/uswds-custom-stepper.component.html
+++ b/libs/documentation/src/lib/components/formly-stepper/demos/uswds-stepper/uswds-custom-stepper.component.html
@@ -10,7 +10,7 @@
 
 <div class="grid-row grid-gap flex-justify-center margin-top-4">
   <div class="margin-right-1">
-    <button class="usa-button sds-button--circle usa-button--base usa-button--big padding-2" sdsStepperPrevious
+    <button class="usa-button sds-button--circle usa-button--base usa-button--big" sdsStepperPrevious
       [attr.id]="id + '-prevBtn'">
       <usa-icon [icon]="'chevron-left'"></usa-icon>
     </button>
@@ -22,7 +22,7 @@
 
 
   <div class="margin-right-1">
-    <button class="usa-button sds-button--circle usa-button--big usa-button--base padding-2" sdsStepperSave
+    <button class="usa-button sds-button--circle usa-button--big usa-button--base" sdsStepperSave
       [attr.id]="id + '-saveBtn'">
       <usa-icon [icon]="'save'"></usa-icon>
     </button>
@@ -33,7 +33,7 @@
 
   <div class="margin-right-1">
     <button #saveAndContinueBtn
-      class="usa-button sds-button--circle usa-button--base usa-button--big usa-button--active padding-2"
+      class="usa-button sds-button--circle usa-button--base usa-button--big usa-button--active"
       sdsStepperNext [attr.id]="id + '-nextBtn'">
       <usa-icon [icon]="'chevron-right'"></usa-icon>
     </button>


### PR DESCRIPTION
## Description
Updated classes applied to buttons in stepper examples. Specifically removed `padding-2`. This class made no change to the appearance on other browsers, but in safari it pushed the icons down.

## Motivation and Context
#938 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

