### PR TITLE
IAEMOD-1254: Change error icon in alert modal

### DIFF
--- a/libs/packages/components/src/lib/dialog/dialog-container.component.html
+++ b/libs/packages/components/src/lib/dialog/dialog-container.component.html
@@ -4,7 +4,7 @@
 
 <!-- Alert Icons -->
 <div *ngIf="_config.alert" [ngSwitch]="_config.alert" class="sds-dialog-icon">
-  <usa-icon *ngSwitchCase="'error'" [icon]="'alert-error'" size="3x"></usa-icon>
+  <usa-icon *ngSwitchCase="'error'" [icon]="'exclamation-circle'" size="3x"></usa-icon>
   <usa-icon *ngSwitchCase="'warning'" [icon]="'exclamation-triangle'" size="3x"></usa-icon>
   <usa-icon *ngSwitchCase="'info'" [icon]="'info-circle'" size="3x"></usa-icon>
   <usa-icon *ngSwitchCase="'success'" [icon]="'check-circle'" size="3x"></usa-icon>

--- a/libs/packages/components/src/lib/dialog/dialog.module.ts
+++ b/libs/packages/components/src/lib/dialog/dialog.module.ts
@@ -2,7 +2,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { NgxBootstrapIconsModule, x, infoCircle, exclamationTriangle } from 'ngx-bootstrap-icons';
+import { NgxBootstrapIconsModule, x, infoCircle, exclamationTriangle, exclamationCircle } from 'ngx-bootstrap-icons';
 import {
   SDS_DIALOG_SCROLL_STRATEGY_PROVIDER,
   SDS_SLIDE_OUT_SCROLL_STRATEGY_PROVIDER,
@@ -25,7 +25,7 @@ import {
     OverlayModule,
     PortalModule,
     IconModule,
-    NgxBootstrapIconsModule.pick({ x, alertError, infoCircle, exclamationTriangle }),
+    NgxBootstrapIconsModule.pick({ x, alertError, infoCircle, exclamationTriangle, exclamationCircle }),
   ],
   exports: [
     SdsDialogContainerComponent,


### PR DESCRIPTION
## Description
Updated dialog container to use exclamation-circle rather than alert-error icon when alert type is error.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEMOD-1254

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="563" alt="Screen Shot 2022-06-21 at 11 05 49 AM" src="https://user-images.githubusercontent.com/72805180/174834302-17085f0b-4d2f-404b-bbcb-61959abf079e.png">


## Which browsers have you tested?
- [x] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

