### PR TITLE
IAEMOD-2786: Update code to use childRef rather than css selector

### DIFF
--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -46,8 +46,6 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
 
   loadVideoSource = false;
 
-  playerId: string;
-
   constructor(
     private elementRef: ElementRef,
     private renderer2: Renderer2,
@@ -65,12 +63,11 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
     if (this.VPConfiguration.preload != 'none') {
       this.loadVideoSource = true;
     }
-    this.playerId = 'videoPlayer' + this.VPConfiguration.id;
   }
 
   ngAfterViewInit() {
     if (this.crossorigin) {
-      const id = this.elementRef.nativeElement.querySelector(`#${this.playerId}`);
+      const id = this.video.nativeElement;
       id.setAttribute('crossorigin', this.crossorigin);
     }
     this.config = {
@@ -81,7 +78,6 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
       debug: this.VPConfiguration.debug,
     };
 
-    const video = new InitPxVideo(this.config);
     this.video.nativeElement.setAttribute('style', 'width:' + this.VPConfiguration.width + ';');
 
     const progressElement: HTMLProgressElement = this.elementRef.nativeElement.querySelector('progress');
@@ -97,7 +93,7 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
 
   ngOnChanges(changes) {
     if (changes && changes.crossorigin) {
-      const id = this.elementRef.nativeElement.querySelector(`#${this.playerId}`);
+      const id = this.video.nativeElement;
       if (id) {
         id.setAttribute('crossorigin', this.crossorigin);
       }
@@ -112,7 +108,7 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
   private _loadVideoSourceOnDemand() {
     const playButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-play');
     const restartButton: HTMLButtonElement = this.elementRef.nativeElement.querySelector('.px-video-restart');
-    const video: HTMLVideoElement = this.elementRef.nativeElement.querySelector(`#${this.playerId}`);
+    const video: HTMLVideoElement = this.video.nativeElement;
 
     const loadVideo = ($event) => {
       if (this.loadVideoSource) {


### PR DESCRIPTION
## Description
Video player was throwing an error when  id provided in config contained a period. This PR updates the logic to get the video element to use childRef rather than css selector.

## Motivation and Context
https://cm-jira.usa.gov/browse/IAEMOD-2786

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="1792" alt="Screen Shot 2022-07-29 at 7 05 57 AM" src="https://user-images.githubusercontent.com/72805180/181746536-b02c8768-5218-4de1-8db2-89e3910ce33d.png">

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari
