### PR TITLE
Fix to ensure that custom controls are used on video player

### DIFF
--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -78,6 +78,8 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
       debug: this.VPConfiguration.debug,
     };
 
+    const video = new InitPxVideo(this.config); // Required to ensure that browser controls are replaced with custom controls
+    
     this.video.nativeElement.setAttribute('style', 'width:' + this.VPConfiguration.width + ';');
 
     const progressElement: HTMLProgressElement = this.elementRef.nativeElement.querySelector('progress');

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -79,7 +79,7 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
     };
 
     const video = new InitPxVideo(this.config); // Required to ensure that browser controls are replaced with custom controls
-    
+
     this.video.nativeElement.setAttribute('style', 'width:' + this.VPConfiguration.width + ';');
 
     const progressElement: HTMLProgressElement = this.elementRef.nativeElement.querySelector('progress');


### PR DESCRIPTION
## Description
Fixes #1048. Add constructor call that seems to add custom controls to video player

## Motivation and Context
IAEMOD-5912

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="1016" alt="Screen Shot 2022-10-18 at 3 22 21 PM" src="https://user-images.githubusercontent.com/72805180/196524591-c68c6d9c-f9af-4016-a203-711eb1a9eb7a.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

