### PR TITLE
IAEMOD-6049: Address actions menu and horizontal filter 508 issues

### DIFF
--- a/apps/sam-design-system-site/src/sds-styles.scss
+++ b/apps/sam-design-system-site/src/sds-styles.scss
@@ -6,5 +6,3 @@ $theme-image-path: '~@gsa-sam/sam-styles/src/img';
 $theme-font-path: '~@gsa-sam/sam-styles/src/fonts';
 
 @import '~@gsa-sam/sam-styles/src/stylesheets/sam';
-
-

--- a/libs/packages/components/src/lib/actions-menu/actions-menu.component.html
+++ b/libs/packages/components/src/lib/actions-menu/actions-menu.component.html
@@ -5,6 +5,7 @@
   [class.sds-button--shadow]="model.trigger.shadow"
   [class.sds-button--small]="size === 'sm'"
   [sdsMenuTriggerFor]="menu"
+  role="button"
 >
   <usa-icon [icon]="'three-dots-vertical'" [size]="'1x'"></usa-icon>
   <span class="usa-sr-only">{{ screenReaderText }}</span>

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -150,7 +150,7 @@ export class SdsPopoverDirective implements AfterViewInit {
       this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'false');
       this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.popoverDivId);
       this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'true');
-      // this.renderer.setAttribute(this.el.nativeElement, 'role', 'none'); 
+
       this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     } else {
       this.hidePopover();
@@ -162,7 +162,6 @@ export class SdsPopoverDirective implements AfterViewInit {
     this.renderer.addClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'true');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
-    // this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
 
     this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__shown');
     this.renderer.removeAttribute(this.el.nativeElement, 'aria-describedby');

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -150,7 +150,7 @@ export class SdsPopoverDirective implements AfterViewInit {
       this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'false');
       this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.popoverDivId);
       this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'true');
-      // this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
+      this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
       this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     } else {
       this.hidePopover();
@@ -162,7 +162,7 @@ export class SdsPopoverDirective implements AfterViewInit {
     this.renderer.addClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'true');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
-    // this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
+    this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
 
     this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__shown');
     this.renderer.removeAttribute(this.el.nativeElement, 'aria-describedby');

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -99,7 +99,7 @@ export class SdsPopoverDirective implements AfterViewInit {
 
     this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
-    this.renderer.setAttribute(this.el.nativeElement, 'aria-haspopup', 'dialog');
+    // this.renderer.setAttribute(this.el.nativeElement, 'aria-haspopup', 'dialog');
 
     this.renderer.appendChild(this.el.nativeElement, this.sdsPopoverDiv);
   }

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -150,7 +150,7 @@ export class SdsPopoverDirective implements AfterViewInit {
       this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'false');
       this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.popoverDivId);
       this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'true');
-      this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
+      // this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
       this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     } else {
       this.hidePopover();
@@ -162,7 +162,7 @@ export class SdsPopoverDirective implements AfterViewInit {
     this.renderer.addClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'true');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
-    this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
+    // this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
 
     this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__shown');
     this.renderer.removeAttribute(this.el.nativeElement, 'aria-describedby');

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -99,7 +99,7 @@ export class SdsPopoverDirective implements AfterViewInit {
 
     this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
-    // this.renderer.setAttribute(this.el.nativeElement, 'aria-haspopup', 'dialog');
+    this.renderer.setAttribute(this.el.nativeElement, 'aria-haspopup', 'dialog');
 
     this.renderer.appendChild(this.el.nativeElement, this.sdsPopoverDiv);
   }

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -150,7 +150,7 @@ export class SdsPopoverDirective implements AfterViewInit {
       this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'false');
       this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.popoverDivId);
       this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'true');
-
+      this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
       this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     } else {
       this.hidePopover();
@@ -162,6 +162,7 @@ export class SdsPopoverDirective implements AfterViewInit {
     this.renderer.addClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'true');
     this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'false');
+    this.renderer.setAttribute(this.el.nativeElement, 'role', 'button');
 
     this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__shown');
     this.renderer.removeAttribute(this.el.nativeElement, 'aria-describedby');

--- a/libs/packages/components/src/lib/popover/popover.directive.ts
+++ b/libs/packages/components/src/lib/popover/popover.directive.ts
@@ -150,7 +150,7 @@ export class SdsPopoverDirective implements AfterViewInit {
       this.renderer.setAttribute(this.sdsPopoverDiv, 'aria-hidden', 'false');
       this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', this.popoverDivId);
       this.renderer.setAttribute(this.el.nativeElement, 'aria-expanded', 'true');
-      // this.renderer.setAttribute(this.el.nativeElement, 'role', 'none');
+      // this.renderer.setAttribute(this.el.nativeElement, 'role', 'none'); 
       this.renderer.removeClass(this.sdsPopoverDiv, 'sds-popover__hidden');
     } else {
       this.hidePopover();

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -73,7 +73,7 @@
 
 <!-- Chip Display -->
 <ng-container *ngIf="displayChips">
-  <p class="usa-sr-only" id="chip-status-announce">{{chipStatusText}}</p>
+  <p class="usa-sr-only" id="chip-status-announce" aria-live="polite">{{chipStatusText}}</p>
   <div *ngFor="let chip of chips" class="width-auto sds-tag sds-tag--chip sds-tag--input margin-right-2">
     <div class="sds--tag__item">
       <sds-readonly-container

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -73,7 +73,7 @@
 
 <!-- Chip Display -->
 <ng-container *ngIf="displayChips">
-  <p class="usa-sr-only" id="chip-status-announce" aria-live="polite">{{chipStatusText}}</p>
+  <p class="usa-sr-only" id="chip-status-announce" aria-live="polite">{{ chipStatusText }}</p>
   <div *ngFor="let chip of chips" class="width-auto sds-tag sds-tag--chip sds-tag--input margin-right-2">
     <div class="sds--tag__item">
       <sds-readonly-container

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -73,6 +73,7 @@
 
 <!-- Chip Display -->
 <ng-container *ngIf="displayChips">
+  <p class="usa-sr-only" id="chip-status-announce">{{chipStatusText}}</p>
   <div *ngFor="let chip of chips" class="width-auto sds-tag sds-tag--chip sds-tag--input margin-right-2">
     <div class="sds--tag__item">
       <sds-readonly-container

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -117,6 +117,8 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   chips: ReadonlyDataType[] = [];
   dialogRef: SdsDialogRef<any>;
 
+  chipStatusText = "";
+
   // Snapshot of model before filter dialog opens during horizontal responsive format
   _modelSnapshot: any;
 
@@ -428,6 +430,9 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
       });
     });
 
+    const {added, deleted} = this.findChipDifferences(this.chips, allChips);
+    this.chipAdded(added);
+    this.chipRemoved(deleted);  
     this.chips = allChips;
   }
 
@@ -478,5 +483,59 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
     const objectValue = {};
     Object.assign(objectValue, ...existingValues);
     field.formControl.setValue(objectValue);
+  }
+
+  chipAdded(added: ReadonlyDataType | ReadonlyDataType[]): void {
+    if(!this.displayChips){
+      return;
+    }
+    let statusText = "";
+    if(Array.isArray(added)){
+      if(added.length === 0 ){
+        return;
+      }
+      for (let i = 0; i < added.length; i++) {
+        statusText = statusText.concat(`Filter ${added[i].label} ${added[i].srValue} added.`)  
+      }
+    } else {
+      statusText = `Filter ${added.label} ${added.srValue} added.`
+    }
+    this.chipStatusText = statusText;
+  }
+  chipRemoved(removed: ReadonlyDataType | ReadonlyDataType[]): void {
+    if(!this.displayChips){
+      return;
+    }
+    let statusText = "";
+    if(Array.isArray(removed)){
+      if(removed.length === 0 ){
+        return;
+      }
+      for (let i = 0; i < removed.length; i++) {
+        statusText = statusText.concat(`Filter ${removed[i].label} ${removed[i].srValue} removed.`)  
+      }
+    } else {
+      statusText = `Filter ${removed.label} ${removed.srValue} removed.`
+    }
+    this.chipStatusText = statusText;
+  }
+  findChipDifferences(oldChips: ReadonlyDataType[], newChips: ReadonlyDataType[]): {
+    added: ReadonlyDataType[],
+    deleted: ReadonlyDataType[]
+  }
+  {
+    const deleted = oldChips
+      .filter(oldChip => newChips
+        .findIndex(newChip => this.sameChip(newChip, oldChip)) === -1
+      )
+    const added = newChips
+      .filter(newChip => oldChips
+        .findIndex(oldChip => this.sameChip(newChip, oldChip)) === -1
+      )
+    return {added, deleted};
+  }
+
+  sameChip(chipA: ReadonlyDataType, chipB: ReadonlyDataType): boolean{
+    return chipA.srValue === chipB.srValue;
   }
 }

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.ts
@@ -22,7 +22,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { FormlyUtilsService, ReadonlyDataType } from '../formly/services/formly-utils.service';
 import { SdsFormlyTypes } from '../formly/models/formly-types';
-import { SdsDialogRef, SdsDialogService, SDS_DIALOG_DATA } from '@gsa-sam/components';
+import { SdsDialogRef, SdsDialogService } from '@gsa-sam/components';
 import { cloneDeep } from 'lodash-es';
 import { FormlyValueChangeEvent } from '@ngx-formly/core/lib/components/formly.field.config';
 @Component({
@@ -117,7 +117,7 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   chips: ReadonlyDataType[] = [];
   dialogRef: SdsDialogRef<any>;
 
-  chipStatusText = "";
+  chipStatusText = '';
 
   // Snapshot of model before filter dialog opens during horizontal responsive format
   _modelSnapshot: any;
@@ -430,9 +430,9 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
       });
     });
 
-    const {added, deleted} = this.findChipDifferences(this.chips, allChips);
+    const { added, deleted } = this.findChipDifferences(this.chips, allChips);
     this.chipAdded(added);
-    this.chipRemoved(deleted);  
+    this.chipRemoved(deleted);
     this.chips = allChips;
   }
 
@@ -486,56 +486,54 @@ export class SdsFiltersComponent implements OnInit, OnChanges {
   }
 
   chipAdded(added: ReadonlyDataType | ReadonlyDataType[]): void {
-    if(!this.displayChips){
+    if (!this.displayChips) {
       return;
     }
-    let statusText = "";
-    if(Array.isArray(added)){
-      if(added.length === 0 ){
+    let statusText = '';
+    if (Array.isArray(added)) {
+      if (added.length === 0) {
         return;
       }
       for (let i = 0; i < added.length; i++) {
-        statusText = statusText.concat(`Filter ${added[i].label} ${added[i].srValue} added.`)  
+        statusText = statusText.concat(`Filter ${added[i].label} ${added[i].srValue} added.`);
       }
     } else {
-      statusText = `Filter ${added.label} ${added.srValue} added.`
+      statusText = `Filter ${added.label} ${added.srValue} added.`;
     }
     this.chipStatusText = statusText;
   }
   chipRemoved(removed: ReadonlyDataType | ReadonlyDataType[]): void {
-    if(!this.displayChips){
+    if (!this.displayChips) {
       return;
     }
-    let statusText = "";
-    if(Array.isArray(removed)){
-      if(removed.length === 0 ){
+    let statusText = '';
+    if (Array.isArray(removed)) {
+      if (removed.length === 0) {
         return;
       }
       for (let i = 0; i < removed.length; i++) {
-        statusText = statusText.concat(`Filter ${removed[i].label} ${removed[i].srValue} removed.`)  
+        statusText = statusText.concat(`Filter ${removed[i].label} ${removed[i].srValue} removed.`);
       }
     } else {
-      statusText = `Filter ${removed.label} ${removed.srValue} removed.`
+      statusText = `Filter ${removed.label} ${removed.srValue} removed.`;
     }
     this.chipStatusText = statusText;
   }
-  findChipDifferences(oldChips: ReadonlyDataType[], newChips: ReadonlyDataType[]): {
-    added: ReadonlyDataType[],
-    deleted: ReadonlyDataType[]
-  }
-  {
-    const deleted = oldChips
-      .filter(oldChip => newChips
-        .findIndex(newChip => this.sameChip(newChip, oldChip)) === -1
-      )
-    const added = newChips
-      .filter(newChip => oldChips
-        .findIndex(oldChip => this.sameChip(newChip, oldChip)) === -1
-      )
-    return {added, deleted};
+  findChipDifferences(
+    oldChips: ReadonlyDataType[],
+    newChips: ReadonlyDataType[]
+  ): {
+    added: ReadonlyDataType[];
+    deleted: ReadonlyDataType[];
+  } {
+    const deleted = oldChips.filter(
+      (oldChip) => newChips.findIndex((newChip) => this.sameChip(newChip, oldChip)) === -1
+    );
+    const added = newChips.filter((newChip) => oldChips.findIndex((oldChip) => this.sameChip(newChip, oldChip)) === -1);
+    return { added, deleted };
   }
 
-  sameChip(chipA: ReadonlyDataType, chipB: ReadonlyDataType): boolean{
+  sameChip(chipA: ReadonlyDataType, chipB: ReadonlyDataType): boolean {
     return chipA.srValue === chipB.srValue;
   }
 }

--- a/libs/packages/sam-formly/src/lib/formly/services/formly-utils.service.ts
+++ b/libs/packages/sam-formly/src/lib/formly/services/formly-utils.service.ts
@@ -9,6 +9,7 @@ export interface ReadonlyDataType {
   value: any;
   readonlyOptions: ReadonlyOptions;
   formlyKey: string;
+  srValue: string;
 }
 @Injectable()
 export class FormlyUtilsService {


### PR DESCRIPTION
## Description
Address actions menu and horizontal filter 508 issues. This changes ensures that actions menu button and the resulting menu is treated as a menu and give all screenreader outputs that a menu does. This also updates the horizontal filters to add some screen-reader only text which announces as filters are added and removed.

## Motivation and Context
#1056 
#1054 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

