### PR TITLE
IAEMOD-7310: Fix tooltip icon alignment

### DIFF
--- a/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.component.html
+++ b/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #temp let-item>
   <div class="sds-card sds-card--bordered">
-    <div class="sds-card__header" style="display: flex; justify-content: center; align-items: center">
+    <div class="sds-card__header sds-card__header--center">
       <div class="sds-card__icon margin-left-2">
         <usa-icon [icon]="'book'" [classes]="['search']" size="2x"></usa-icon>
       </div>

--- a/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.component.html
+++ b/libs/documentation/src/lib/components/result-list/demos/template/result-list-template.component.html
@@ -13,7 +13,7 @@
 
 <ng-template #temp let-item>
   <div class="sds-card sds-card--bordered">
-    <div class="sds-card__header sds-card__header--center">
+    <div class="sds-card__header" style="display: flex; justify-content: center; align-items: center">
       <div class="sds-card__icon margin-left-2">
         <usa-icon [icon]="'book'" [classes]="['search']" size="2x"></usa-icon>
       </div>

--- a/libs/packages/components/src/lib/search/search.component.scss
+++ b/libs/packages/components/src/lib/search/search.component.scss
@@ -38,4 +38,3 @@ input::-ms-clear {
     max-width: unset;
   }
 }
-

--- a/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
@@ -29,7 +29,8 @@
     <label class="usa-checkbox__label" [for]="id">
       <span [innerHtml]="to.label"></span>
       <span *ngIf="!to.required && !to.hideOptional"> (Optional)</span>
-      <div *ngIf="to.tooltipText" class="margin-left-1" class="usa-checkbox__tooltip">>
+      <div *ngIf="to.tooltipText" class="margin-left-1" class="usa-checkbox__tooltip">
+        >
         <p #tipContent [ngClass]="to.tooltipClass" class="margin-1" [innerHTML]="to.tooltipText"></p>
         <usa-icon
           [position]="to.tooltipPosition ? to.tooltipPosition :'right'"

--- a/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
@@ -29,7 +29,7 @@
     <label class="usa-checkbox__label" [for]="id">
       <span [innerHtml]="to.label"></span>
       <span *ngIf="!to.required && !to.hideOptional"> (Optional)</span>
-      <div *ngIf="to.tooltipText" class="margin-left-1" style="display: inline;">
+      <div *ngIf="to.tooltipText" class="margin-left-1" class="usa-checkbox__tooltip">>
         <p #tipContent [ngClass]="to.tooltipClass" class="margin-1" [innerHTML]="to.tooltipText"></p>
         <usa-icon
           [position]="to.tooltipPosition ? to.tooltipPosition :'right'"

--- a/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/checkbox.html
@@ -29,16 +29,15 @@
     <label class="usa-checkbox__label" [for]="id">
       <span [innerHtml]="to.label"></span>
       <span *ngIf="!to.required && !to.hideOptional"> (Optional)</span>
+      <div *ngIf="to.tooltipText" class="margin-left-1" style="display: inline;">
+        <p #tipContent [ngClass]="to.tooltipClass" class="margin-1" [innerHTML]="to.tooltipText"></p>
+        <usa-icon
+          [position]="to.tooltipPosition ? to.tooltipPosition :'right'"
+          [sdsTooltip]="tipContent"
+          [size]="'lg'"
+          [icon]="'info-circle'"
+        ></usa-icon>
+      </div>
     </label>
-  </div>
-
-  <div *ngIf="to.tooltipText" class="padding-top-3 margin-left-1">
-    <p #tipContent [ngClass]="to.tooltipClass" class="margin-1" [innerHTML]="to.tooltipText"></p>
-    <usa-icon
-      [position]="to.tooltipPosition ? to.tooltipPosition :'right'"
-      [sdsTooltip]="tipContent"
-      [size]="'lg'"
-      [icon]="'info-circle'"
-    ></usa-icon>
   </div>
 </ng-template>

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -29,7 +29,7 @@
       <ng-container class="grid-row" *ngFor="let option of (to.groupOptions | keyvalue); let i = index">
         <div>
           <legend>
-            <span class="text-bold display-block margin-top-1 margin-bottom-05">{{option.key}}</span>
+            <span class="text-bold display-block">{{option.key}}</span>
           </legend>
 
           <ng-container
@@ -52,9 +52,7 @@
 
                 <label
                   class="usa-radio__label"
-                  [ngClass]="{
-              'margin-top-0': j==0 ,
-'{{to.optionsClass}}': to.optionsClass}"
+                  [ngClass]="to.optionsClass ? to.optionsClass : ''"
                   [for]="id + '_' + i+ '_'+ j"
                 >
                   <span [innerHtml]="opt.label"></span>
@@ -67,24 +65,25 @@
                       ></span>
                     </div>
                   </ng-container>
+                  <div *ngIf="option.value[j].tooltipText" style="display: inline;">
+                    <p
+                      #tipContent
+                      [ngClass]="option.value[j].tooltipClass"
+                      class="margin-1"
+                      [innerHTML]="option.value[j].tooltipText"
+                    ></p>
+                    <usa-icon
+                      class="margin-left-1"
+                      [position]="option.value[j].tooltipPosition ? option.value[j].tooltipPosition :'right'"
+                      [sdsTooltip]="tipContent"
+                      [size]="'sm'"
+                      [icon]="'info-circle'"
+                    ></usa-icon>
+                  </div>
                 </label>
               </div>
 
-              <div *ngIf="option.value[j].tooltipText">
-                <p
-                  #tipContent
-                  [ngClass]="option.value[j].tooltipClass"
-                  class="margin-1"
-                  [innerHTML]="option.value[j].tooltipText"
-                ></p>
-                <usa-icon
-                  class="padding-top-105 margin-left-1"
-                  [position]="option.value[j].tooltipPosition ? option.value[j].tooltipPosition :'right'"
-                  [sdsTooltip]="tipContent"
-                  [size]="'sm'"
-                  [icon]="'info-circle'"
-                ></usa-icon>
-              </div>
+              
             </div>
           </ng-container>
         </div>
@@ -94,7 +93,7 @@
 </form>
 
 <ng-template let-option let-i="i" let-to="to" #defaultTemplate>
-  <div class="grid-row" [ngClass]="{'horizontal-option': to.horizontal ,'margin-top-1': to.description && i==0 }">
+  <div class="grid-row" [ngClass]="{'horizontal-option': to.horizontal}">
     <div>
       <input
         class="usa-radio__input"
@@ -108,13 +107,7 @@
         [value]="option.value"
       />
 
-      <label
-        class="usa-radio__label"
-        [ngClass]="{
-              'margin-top-0': i==0 ,
-'{{to.optionsClass}}': to.optionsClass}"
-        [for]="id + '_' + i"
-      >
+      <label class="usa-radio__label" [ngClass]="to.optionsClass ? to.optionsClass : ''" [for]="id + '_' + i">
         <span [innerHtml]="option.label"></span>
         <ng-container *ngIf="to.options[i].description && to.options[i].description.length">
           <div class="usa-checkbox__label-description">
@@ -125,23 +118,24 @@
             ></span>
           </div>
         </ng-container>
+        <div *ngIf="to.options[i].tooltipText" style="display: inline;">
+          <p
+            #tipContent
+            [ngClass]="to.options[i].tooltipClass"
+            class="margin-1"
+            [innerHTML]="to.options[i].tooltipText"
+          ></p>
+          <usa-icon
+            class="margin-left-1"
+            [position]="to.options[i].tooltipPosition ? to.options[i].tooltipPosition :'right'"
+            [sdsTooltip]="tipContent"
+            [size]="'sm'"
+            [icon]="'info-circle'"
+          ></usa-icon>
+        </div>
       </label>
     </div>
 
-    <div *ngIf="to.options[i].tooltipText">
-      <p
-        #tipContent
-        [ngClass]="to.options[i].tooltipClass"
-        class="margin-1"
-        [innerHTML]="to.options[i].tooltipText"
-      ></p>
-      <usa-icon
-        class="padding-top-105 margin-left-1"
-        [position]="to.options[i].tooltipPosition ? to.options[i].tooltipPosition :'right'"
-        [sdsTooltip]="tipContent"
-        [size]="'sm'"
-        [icon]="'info-circle'"
-      ></usa-icon>
-    </div>
+    
   </div>
 </ng-template>

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -65,7 +65,8 @@
                       ></span>
                     </div>
                   </ng-container>
-                  <div *ngIf="option.value[j].tooltipText" class="usa-radio__tooltip">>
+                  <div *ngIf="option.value[j].tooltipText" class="usa-radio__tooltip">
+                    >
                     <p
                       #tipContent
                       [ngClass]="option.value[j].tooltipClass"

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -65,7 +65,7 @@
                       ></span>
                     </div>
                   </ng-container>
-                  <div *ngIf="option.value[j].tooltipText" style="display: inline;">
+                  <div *ngIf="option.value[j].tooltipText" class="usa-radio__tooltip">>
                     <p
                       #tipContent
                       [ngClass]="option.value[j].tooltipClass"
@@ -116,7 +116,7 @@
             ></span>
           </div>
         </ng-container>
-        <div *ngIf="to.options[i].tooltipText" style="display: inline;">
+        <div *ngIf="to.options[i].tooltipText" class="usa-radio__tooltip">
           <p
             #tipContent
             [ngClass]="to.options[i].tooltipClass"

--- a/libs/packages/sam-formly/src/lib/formly/types/radio.html
+++ b/libs/packages/sam-formly/src/lib/formly/types/radio.html
@@ -82,8 +82,6 @@
                   </div>
                 </label>
               </div>
-
-              
             </div>
           </ng-container>
         </div>
@@ -135,7 +133,5 @@
         </div>
       </label>
     </div>
-
-    
   </div>
 </ng-template>


### PR DESCRIPTION
## Description
Moved icon and content to be a part of label so that icon will move as the label text moves

## Motivation and Context
IAEMOD-7310

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
Checkbox before:
<img width="522" alt="Screen Shot 2022-12-07 at 1 01 21 PM" src="https://user-images.githubusercontent.com/72805180/206263323-67eb16ae-3df5-4282-8fcf-d0cd70c6a95a.png">
Checkbox after:
<img width="522" alt="Screen Shot 2022-12-07 at 1 14 08 PM" src="https://user-images.githubusercontent.com/72805180/206263360-84aae639-1207-4855-9dd2-ce302157240a.png">


Radio before:
<img width="522" alt="Screen Shot 2022-12-07 at 1 01 35 PM" src="https://user-images.githubusercontent.com/72805180/206263391-fb2ab071-31f4-4fa3-9da7-3bab1dd4b751.png">
Radio after:
<img width="522" alt="Screen Shot 2022-12-07 at 1 14 15 PM" src="https://user-images.githubusercontent.com/72805180/206263409-0a852d2b-24dc-44ba-b8a0-54acd936a3f4.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

