### PR TITLE
IAEMOD-9185: Add SB demos for formly-input

### DIFF
--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/formly-input--introduction">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.html
@@ -1,5 +1,7 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
 <a href="https://gsa.github.io/sam-design-system/?path=/story/formly-input--introduction">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component } from '@angular/core';
   templateUrl: './formly-input-link-to-sb.component.html',
 })
 export class FormlyInputLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-formly-input-link-to-sb',
+  templateUrl: './formly-input-link-to-sb.component.html',
+})
+export class FormlyInputLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormlyInputLinkToSbComponent } from './formly-input-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [FormlyInputLinkToSbComponent],
+  bootstrap: [FormlyInputLinkToSbComponent],
+  exports: [FormlyInputLinkToSbComponent],
+})
+export class FormlyInputLinkToSbModule { }

--- a/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb/formly-input-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormlyInputLinkToSbComponent } from './formly-input-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [FormlyInputLinkToSbComponent],
   bootstrap: [FormlyInputLinkToSbComponent],
   exports: [FormlyInputLinkToSbComponent],
 })
-export class FormlyInputLinkToSbModule { }
+export class FormlyInputLinkToSbModule {}

--- a/libs/documentation/src/lib/components/formly-input/input.module.ts
+++ b/libs/documentation/src/lib/components/formly-input/input.module.ts
@@ -68,7 +68,7 @@ export const ROUTES = [
     DocumentationComponentsSharedModule,
     InputBasicModule,
     InputOptionalModule,
-    FormlyInputLinkToSbModule
+    FormlyInputLinkToSbModule,
   ],
 })
 export class InputModule {

--- a/libs/documentation/src/lib/components/formly-input/input.module.ts
+++ b/libs/documentation/src/lib/components/formly-input/input.module.ts
@@ -10,9 +10,18 @@ import { ComponentWrapperComponent } from '../../shared/component-wrapper/compon
 import { InputBasicModule } from './demos/basic/input-basic.module';
 import { InputOptionalModule } from './demos/optional/input-optional.module';
 import { InputOptional } from './demos/optional/input-optional.component';
+import { FormlyInputLinkToSbComponent } from './demos/formly-input-link-to-sb/formly-input-link-to-sb.component';
+import { FormlyInputLinkToSbModule } from './demos/formly-input-link-to-sb/formly-input-link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
+  linkToSb: {
+    title: 'New Demos',
+    type: FormlyInputLinkToSbComponent,
+    code: require('!!raw-loader!./demos/formly-input-link-to-sb/formly-input-link-to-sb.component'),
+    markup: require('!!raw-loader!./demos/formly-input-link-to-sb/formly-input-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/formly-input/demos/formly-input-link-to-sb',
+  },
   basic: {
     title: 'Basic Form Input',
     type: InputBasic,
@@ -54,7 +63,13 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, InputBasicModule, InputOptionalModule],
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    InputBasicModule,
+    InputOptionalModule,
+    FormlyInputLinkToSbModule
+  ],
 })
 export class InputModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.ts
@@ -6,11 +6,10 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   selector: 'sds-formly-input-configurable',
   templateUrl: './formly-input-configurable.component.html',
 })
-export class FormlyInputConfigurableComponent{
-
+export class FormlyInputConfigurableComponent {
   @Input('config')
   set config(config: object) {
-    const temp = this.fields[0]
+    const temp = this.fields[0];
     temp['templateOptions'] = config;
     this.fields = [temp];
   }
@@ -30,5 +29,4 @@ export class FormlyInputConfigurableComponent{
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.component.ts
@@ -1,0 +1,34 @@
+import { AfterViewInit, Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-configurable',
+  templateUrl: './formly-input-configurable.component.html',
+})
+export class FormlyInputConfigurableComponent{
+
+  @Input('config')
+  set config(config: object) {
+    const temp = this.fields[0]
+    temp['templateOptions'] = config;
+    this.fields = [temp];
+  }
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        placeholder: 'eg: Acme Corporation',
+        description: 'Enter the name of your entity.',
+        required: true,
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormlyInputConfigurableComponent } from './formly-input-configurable.component';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputConfigurableComponent],
+  exports: [FormlyInputConfigurableComponent],
+  bootstrap: [FormlyInputConfigurableComponent],
+})
+export class FormlyInputConfigurableModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-configurable/formly-input-configurable.module.ts
@@ -6,15 +6,9 @@ import { SdsFormlyModule } from '@gsa-sam/sam-formly';
 import { FormlyModule } from '@ngx-formly/core';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputConfigurableComponent],
   exports: [FormlyInputConfigurableComponent],
   bootstrap: [FormlyInputConfigurableComponent],
 })
-export class FormlyInputConfigurableModule { }
+export class FormlyInputConfigurableModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.ts
@@ -6,8 +6,7 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   selector: 'sds-formly-input-description',
   templateUrl: './formly-input-description.component.html',
 })
-export class FormlyInputDescriptionComponent{
-
+export class FormlyInputDescriptionComponent {
   form = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -17,9 +16,8 @@ export class FormlyInputDescriptionComponent{
       type: 'input',
       templateOptions: {
         label: 'Entity Name',
-        description: 'Description'
+        description: 'Description',
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-description',
+  templateUrl: './formly-input-description.component.html',
+})
+export class FormlyInputDescriptionComponent{
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        description: 'Description'
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputDescriptionComponent } from './formly-input-description.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputDescriptionComponent],
   exports: [FormlyInputDescriptionComponent],
   bootstrap: [FormlyInputDescriptionComponent],
 })
-export class FormlyInputDescriptionModule { }
+export class FormlyInputDescriptionModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-description/formly-input-description.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputDescriptionComponent } from './formly-input-description.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputDescriptionComponent],
+  exports: [FormlyInputDescriptionComponent],
+  bootstrap: [FormlyInputDescriptionComponent],
+})
+export class FormlyInputDescriptionModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.ts
@@ -5,10 +5,8 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-input-disabled',
   templateUrl: './formly-input-disabled.component.html',
-
 })
-export class FormlyInputDisabledComponent{
-
+export class FormlyInputDisabledComponent {
   form = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -18,9 +16,8 @@ export class FormlyInputDisabledComponent{
       type: 'input',
       templateOptions: {
         label: 'Entity Name',
-        disabled: true
+        disabled: true,
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-disabled',
+  templateUrl: './formly-input-disabled.component.html',
+
+})
+export class FormlyInputDisabledComponent{
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        disabled: true
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputDisabledComponent } from './formly-input-disabled.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputDisabledComponent],
+  bootstrap: [FormlyInputDisabledComponent],
+  exports: [FormlyInputDisabledComponent],
+})
+export class FormlyInputDisabledModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-disabled/formly-input-disabled.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputDisabledComponent } from './formly-input-disabled.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputDisabledComponent],
   bootstrap: [FormlyInputDisabledComponent],
   exports: [FormlyInputDisabledComponent],
 })
-export class FormlyInputDisabledModule { }
+export class FormlyInputDisabledModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.html
@@ -1,0 +1,3 @@
+<p>
+  Formly input provides an input for text to formly forms. This input supports a number of features to inform users what sort of input is expected.
+</p>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.html
@@ -1,3 +1,4 @@
 <p>
-  Formly input provides an input for text to formly forms. This input supports a number of features to inform users what sort of input is expected.
+  Formly input provides an input for text to formly forms. This input supports a number of features to inform users what
+  sort of input is expected.
 </p>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-formly-input-introduction',
+  templateUrl: './formly-input-introduction.component.html',
+})
+export class FormlyInputIntroductionComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.component.ts
@@ -5,7 +5,5 @@ import { Component } from '@angular/core';
   templateUrl: './formly-input-introduction.component.html',
 })
 export class FormlyInputIntroductionComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormlyInputIntroductionComponent } from './formly-input-introduction.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [FormlyInputIntroductionComponent],
+  exports: [FormlyInputIntroductionComponent],
+  bootstrap: [FormlyInputIntroductionComponent],
+})
+export class FormlyInputIntroductionModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-introduction/formly-input-introduction.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormlyInputIntroductionComponent } from './formly-input-introduction.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [FormlyInputIntroductionComponent],
   exports: [FormlyInputIntroductionComponent],
   bootstrap: [FormlyInputIntroductionComponent],
 })
-export class FormlyInputIntroductionModule { }
+export class FormlyInputIntroductionModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.ts
@@ -1,0 +1,24 @@
+import { Component, } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-label',
+  templateUrl: './formly-input-label.component.html',
+})
+export class FormlyInputLabelComponent {
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.component.ts
@@ -1,4 +1,4 @@
-import { Component, } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
 
@@ -7,7 +7,6 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: './formly-input-label.component.html',
 })
 export class FormlyInputLabelComponent {
-
   form = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -20,5 +19,4 @@ export class FormlyInputLabelComponent {
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputLabelComponent } from './formly-input-label.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputLabelComponent],
   exports: [FormlyInputLabelComponent],
   bootstrap: [FormlyInputLabelComponent],
 })
-export class FormlyInputLabelModule { }
+export class FormlyInputLabelModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-label/formly-input-label.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputLabelComponent } from './formly-input-label.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputLabelComponent],
+  exports: [FormlyInputLabelComponent],
+  bootstrap: [FormlyInputLabelComponent],
+})
+export class FormlyInputLabelModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.ts
@@ -7,7 +7,6 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: './formly-input-placeholder.component.html',
 })
 export class FormlyInputPlaceholderComponent {
-
   form = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -17,9 +16,8 @@ export class FormlyInputPlaceholderComponent {
       type: 'input',
       templateOptions: {
         label: 'Entity Name',
-        placeholder: 'Placeholder'
+        placeholder: 'Placeholder',
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-placeholder',
+  templateUrl: './formly-input-placeholder.component.html',
+})
+export class FormlyInputPlaceholderComponent {
+
+  form = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        placeholder: 'Placeholder'
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputPlaceholderComponent } from './formly-input-placeholder.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputPlaceholderComponent],
   exports: [FormlyInputPlaceholderComponent],
   bootstrap: [FormlyInputPlaceholderComponent],
 })
-export class FormlyInputPlaceholderModule { }
+export class FormlyInputPlaceholderModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-placeholder/formly-input-placeholder.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputPlaceholderComponent } from './formly-input-placeholder.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputPlaceholderComponent],
+  exports: [FormlyInputPlaceholderComponent],
+  bootstrap: [FormlyInputPlaceholderComponent],
+})
+export class FormlyInputPlaceholderModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.ts
@@ -7,7 +7,6 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: './formly-input-required.component.html',
 })
 export class FormlyInputRequiredComponent {
-
   orm = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -17,9 +16,8 @@ export class FormlyInputRequiredComponent {
       type: 'input',
       templateOptions: {
         label: 'Entity Name',
-        required: true
+        required: true,
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-required',
+  templateUrl: './formly-input-required.component.html',
+})
+export class FormlyInputRequiredComponent {
+
+  orm = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        required: true
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputRequiredComponent } from './formly-input-required.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputRequiredComponent],
+  exports: [FormlyInputRequiredComponent],
+  bootstrap: [FormlyInputRequiredComponent],
+})
+export class FormlyInputRequiredModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-required/formly-input-required.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputRequiredComponent } from './formly-input-required.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputRequiredComponent],
   exports: [FormlyInputRequiredComponent],
   bootstrap: [FormlyInputRequiredComponent],
 })
-export class FormlyInputRequiredModule { }
+export class FormlyInputRequiredModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" [form]="form"></formly-form>
+</form>

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.ts
@@ -1,0 +1,25 @@
+import { Component, } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+
+@Component({
+  selector: 'sds-formly-input-tooltip-text',
+  templateUrl: './formly-input-tooltip-text.component.html',
+})
+export class FormlyInputTooltipTextComponent {
+
+  orm = new FormGroup({});
+  model: any = {};
+  options: FormlyFormOptions = {};
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'title',
+      type: 'input',
+      templateOptions: {
+        label: 'Entity Name',
+        tooltipText: 'Tooltip Text',
+      },
+    },
+  ];
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.component.ts
@@ -1,4 +1,4 @@
-import { Component, } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
 
@@ -7,7 +7,6 @@ import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
   templateUrl: './formly-input-tooltip-text.component.html',
 })
 export class FormlyInputTooltipTextComponent {
-
   orm = new FormGroup({});
   model: any = {};
   options: FormlyFormOptions = {};
@@ -21,5 +20,4 @@ export class FormlyInputTooltipTextComponent {
       },
     },
   ];
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.module.ts
@@ -6,15 +6,9 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyInputTooltipTextComponent } from './formly-input-tooltip-text.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot(),
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyInputTooltipTextComponent],
   exports: [FormlyInputTooltipTextComponent],
   bootstrap: [FormlyInputTooltipTextComponent],
 })
-export class FormlyInputTooltipTextModule { }
+export class FormlyInputTooltipTextModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-tooltip-text/formly-input-tooltip-text.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyInputTooltipTextComponent } from './formly-input-tooltip-text.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot(),
+  ],
+  declarations: [FormlyInputTooltipTextComponent],
+  exports: [FormlyInputTooltipTextComponent],
+  bootstrap: [FormlyInputTooltipTextComponent],
+})
+export class FormlyInputTooltipTextModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
@@ -1,0 +1,235 @@
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import {
+} from '@gsa-sam/sam-material-extensions';
+import { FormlyModule } from '@ngx-formly/core';
+import { moduleMetadata, Meta, Story } from '@storybook/angular';
+import { generateConfig, generateStackblitzLink } from 'libs/documentation/src/sandbox/sandbox-utils';
+import { FormlyInputConfigurableModule } from './formly-input-configurable/formly-input-configurable.module';
+import { FormlyInputDescriptionModule } from './formly-input-description/formly-input-description.module';
+import { FormlyInputDisabledModule } from './formly-input-disabled/formly-input-disabled.module';
+import { FormlyInputIntroductionModule } from './formly-input-introduction/formly-input-introduction.module';
+import { FormlyInputLabelModule } from './formly-input-label/formly-input-label.module';
+import { FormlyInputPlaceholderModule } from './formly-input-placeholder/formly-input-placeholder.module';
+import { FormlyInputRequiredModule } from './formly-input-required/formly-input-required.module';
+import { FormlyInputTooltipTextModule } from './formly-input-tooltip-text/formly-input-tooltip-text.module';
+const disable = {
+  table: {
+    disable: true,
+  },
+};
+const templateOptions = {
+  table: {
+    category: 'template-options',
+  },
+}
+
+export default {
+  title: 'Formly/Input',
+  // component: SdsButtonGroupComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        SdsFormlyModule,
+        FormsModule,
+        FormlyModule.forRoot(),
+        FormlyInputIntroductionModule,
+        FormlyInputConfigurableModule,
+        NoopAnimationsModule,
+        FormlyInputLabelModule,
+        FormlyInputDescriptionModule,
+        FormlyInputDisabledModule,
+        FormlyInputTooltipTextModule,
+        FormlyInputRequiredModule,
+        FormlyInputPlaceholderModule
+      ],
+    }),
+  ],
+  argTypes: {
+    label:templateOptions,
+    placeholder:templateOptions,
+    description:templateOptions,
+    required:templateOptions,
+    disabled:templateOptions,
+    tooltipText:templateOptions,
+  },
+} as Meta;
+
+const formlyConfigFunction = (
+  label: string,
+  placeholder: string,
+  description: string,
+  required: boolean,
+  disabled: boolean,
+  tooltipText: string,
+) => {
+  return {
+    label: label ?? '',
+    placeholder: placeholder ?? '',
+    description: description ?? '',
+    required: required ?? false,
+    disabled: disabled ?? false,
+    tooltipText: tooltipText ?? '',
+  };
+};
+const Template: Story = (args) => {
+  const {
+    label,
+    placeholder,
+    description,
+    required,
+    disabled,
+    tooltipText
+  } = args;
+  let config = formlyConfigFunction(
+    label,
+    placeholder,
+    description,
+    required,
+    disabled,
+    tooltipText
+  )
+  return {
+    template: '<sds-formly-input-configurable [config]="configObj"></sds-formly-input-configurable>',
+    props: {
+      configObj: config,
+      ...args
+    },
+  }
+};
+
+
+export const Configurable = Template.bind({});
+Configurable.args = {
+  label:'Label',
+  placeholder:'Placeholder',
+  description:'Description',
+  required:false,
+  disabled:false,
+  tooltipText:'',
+};
+Configurable.parameters = {
+  preview: { disabled: true },
+};
+
+export const Label: Story = (args) => ({
+  template: '<sds-formly-input-label></sds-formly-input-label>',
+  props: args
+});
+Label.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-label',
+    'FormlyInputLabelModule',
+    'sds-formly-input-label'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'input-label'),
+}
+export const TooltipText: Story = (args) => ({
+  template: '<sds-formly-input-tooltip-text></sds-formly-input-tooltip-text>',
+  props: args
+});
+TooltipText.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-tooltip-text',
+    'FormlyInputTooltipTextModule',
+    'sds-formly-input-tooltip-text'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'tooltip-text'),
+}
+export const Description: Story = (args) => ({
+  template: '<sds-formly-input-description></sds-formly-input-description>',
+  props: args
+});
+Description.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-description',
+    'FormlyInputDescriptionModule',
+    'sds-formly-input-description'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'description'),
+}
+
+export const Disabled: Story = (args) => ({
+  template: '<sds-formly-input-disabled></sds-formly-input-disabled>',
+  props: args
+});
+Disabled.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-disabled',
+    'FormlyInputDisabledModule',
+    'sds-formly-input-disabled'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'disabled'),
+}
+
+export const Required: Story = (args) => ({
+  template: '<sds-formly-input-required></sds-formly-input-required>',
+  props: args
+});
+Required.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-required',
+    'FormlyInputRequiredModule',
+    'sds-formly-input-required'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'required'),
+}
+
+export const Placeholder: Story = (args) => ({
+  template: '<sds-formly-input-placeholder></sds-formly-input-placeholder>',
+  props: args
+});
+Placeholder.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig(
+    'storybook/formly/formly-input/formly-input-placeholder',
+    'FormlyInputPlaceholderModule',
+    'sds-formly-input-placeholder'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-input', 'placeholder'),
+}
+
+
+export const __namedExportsOrder = [
+  'Introduction',
+  'Configurable',
+  'Description',
+  'Disabled',
+  'Label',
+  'Placeholder',
+  'Required',
+  'TooltipText',
+];

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
@@ -45,7 +45,8 @@ export default {
         FormlyInputDisabledModule,
         FormlyInputTooltipTextModule,
         FormlyInputRequiredModule,
-        FormlyInputPlaceholderModule
+        FormlyInputPlaceholderModule,
+        FormlyInputIntroductionModule
       ],
     }),
   ],
@@ -102,6 +103,11 @@ const Template: Story = (args) => {
   }
 };
 
+export const Introduction: Story = (args) => ({
+  template: '<sds-formly-input-introduction></sds-formly-input-introduction>',
+  props: args
+});
+Introduction.parameters = {options: {showPanel: false}};
 
 export const Configurable = Template.bind({});
 Configurable.args = {

--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input.stories.ts
@@ -2,8 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SdsFormlyModule } from '@gsa-sam/sam-formly';
-import {
-} from '@gsa-sam/sam-material-extensions';
+import {} from '@gsa-sam/sam-material-extensions';
 import { FormlyModule } from '@ngx-formly/core';
 import { moduleMetadata, Meta, Story } from '@storybook/angular';
 import { generateConfig, generateStackblitzLink } from 'libs/documentation/src/sandbox/sandbox-utils';
@@ -24,7 +23,7 @@ const templateOptions = {
   table: {
     category: 'template-options',
   },
-}
+};
 
 export default {
   title: 'Formly/Input',
@@ -46,17 +45,17 @@ export default {
         FormlyInputTooltipTextModule,
         FormlyInputRequiredModule,
         FormlyInputPlaceholderModule,
-        FormlyInputIntroductionModule
+        FormlyInputIntroductionModule,
       ],
     }),
   ],
   argTypes: {
-    label:templateOptions,
-    placeholder:templateOptions,
-    description:templateOptions,
-    required:templateOptions,
-    disabled:templateOptions,
-    tooltipText:templateOptions,
+    label: templateOptions,
+    placeholder: templateOptions,
+    description: templateOptions,
+    required: templateOptions,
+    disabled: templateOptions,
+    tooltipText: templateOptions,
   },
 } as Meta;
 
@@ -66,7 +65,7 @@ const formlyConfigFunction = (
   description: string,
   required: boolean,
   disabled: boolean,
-  tooltipText: string,
+  tooltipText: string
 ) => {
   return {
     label: label ?? '',
@@ -78,45 +77,31 @@ const formlyConfigFunction = (
   };
 };
 const Template: Story = (args) => {
-  const {
-    label,
-    placeholder,
-    description,
-    required,
-    disabled,
-    tooltipText
-  } = args;
-  let config = formlyConfigFunction(
-    label,
-    placeholder,
-    description,
-    required,
-    disabled,
-    tooltipText
-  )
+  const { label, placeholder, description, required, disabled, tooltipText } = args;
+  let config = formlyConfigFunction(label, placeholder, description, required, disabled, tooltipText);
   return {
     template: '<sds-formly-input-configurable [config]="configObj"></sds-formly-input-configurable>',
     props: {
       configObj: config,
-      ...args
+      ...args,
     },
-  }
+  };
 };
 
 export const Introduction: Story = (args) => ({
   template: '<sds-formly-input-introduction></sds-formly-input-introduction>',
-  props: args
+  props: args,
 });
-Introduction.parameters = {options: {showPanel: false}};
+Introduction.parameters = { options: { showPanel: false } };
 
 export const Configurable = Template.bind({});
 Configurable.args = {
-  label:'Label',
-  placeholder:'Placeholder',
-  description:'Description',
-  required:false,
-  disabled:false,
-  tooltipText:'',
+  label: 'Label',
+  placeholder: 'Placeholder',
+  description: 'Description',
+  required: false,
+  disabled: false,
+  tooltipText: '',
 };
 Configurable.parameters = {
   preview: { disabled: true },
@@ -124,7 +109,7 @@ Configurable.parameters = {
 
 export const Label: Story = (args) => ({
   template: '<sds-formly-input-label></sds-formly-input-label>',
-  props: args
+  props: args,
 });
 Label.parameters = {
   controls: {
@@ -138,10 +123,10 @@ Label.parameters = {
     'sds-formly-input-label'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'input-label'),
-}
+};
 export const TooltipText: Story = (args) => ({
   template: '<sds-formly-input-tooltip-text></sds-formly-input-tooltip-text>',
-  props: args
+  props: args,
 });
 TooltipText.parameters = {
   controls: {
@@ -155,10 +140,10 @@ TooltipText.parameters = {
     'sds-formly-input-tooltip-text'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'tooltip-text'),
-}
+};
 export const Description: Story = (args) => ({
   template: '<sds-formly-input-description></sds-formly-input-description>',
-  props: args
+  props: args,
 });
 Description.parameters = {
   controls: {
@@ -172,11 +157,11 @@ Description.parameters = {
     'sds-formly-input-description'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'description'),
-}
+};
 
 export const Disabled: Story = (args) => ({
   template: '<sds-formly-input-disabled></sds-formly-input-disabled>',
-  props: args
+  props: args,
 });
 Disabled.parameters = {
   controls: {
@@ -190,11 +175,11 @@ Disabled.parameters = {
     'sds-formly-input-disabled'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'disabled'),
-}
+};
 
 export const Required: Story = (args) => ({
   template: '<sds-formly-input-required></sds-formly-input-required>',
-  props: args
+  props: args,
 });
 Required.parameters = {
   controls: {
@@ -208,11 +193,11 @@ Required.parameters = {
     'sds-formly-input-required'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'required'),
-}
+};
 
 export const Placeholder: Story = (args) => ({
   template: '<sds-formly-input-placeholder></sds-formly-input-placeholder>',
-  props: args
+  props: args,
 });
 Placeholder.parameters = {
   controls: {
@@ -226,8 +211,7 @@ Placeholder.parameters = {
     'sds-formly-input-placeholder'
   ),
   stackblitzLink: generateStackblitzLink('formly-input', 'placeholder'),
-}
-
+};
 
 export const __namedExportsOrder = [
   'Introduction',

--- a/misc/generate-stackblitzes.ts
+++ b/misc/generate-stackblitzes.ts
@@ -123,10 +123,11 @@ modulesInfo.forEach((value, demoModule) => {
   demoFolder = path.relative(root, path.resolve(demoFolder));
 
   const splitDemoFolder = demoFolder
-    .replace(root, '')
-    .split(path.sep);
-  const componentName = splitDemoFolder[1];
-  const demoName = splitDemoFolder[demoFolder.startsWith('storybook')?2:3];
+  .replace(root, '')
+  .split(path.sep);
+  const isStorybookDemo = demoFolder.startsWith('storybook');
+  const componentName = splitDemoFolder[splitDemoFolder.length - (isStorybookDemo ? 2 : 3)];
+  const demoName = splitDemoFolder[splitDemoFolder.length - 1];
   const modulePath = path.basename(demoModule, '.ts');
 
   const moduleInfo = modulesInfo.get(demoModule);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sam-design-system",
-  "version": "13.0.3",
+  "version": "13.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -423,11 +423,11 @@
       "dev": true
     },
     "@angular/material": {
-      "version": "12.2.13",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-12.2.13.tgz",
-      "integrity": "sha512-6g2GyN4qp2D+DqY2AwrQuPB3cd9gybvQVXvNRbTPXEulHr+LgGei00ySdFHFp6RvdGSMZ4i3LM1Fq3VkFxhCfQ==",
+      "version": "13.3.9",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-13.3.9.tgz",
+      "integrity": "sha512-FU8lcMgo+AL8ckd27B4V097ZPoIZNRHiCe3wpgkImT1qC0YwcyXZVn0MqQTTFSdC9a/aI8wPm3AbTClJEVw5Vw==",
       "requires": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.0"
       }
     },
     "@angular/platform-browser": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@angular/compiler-cli": "^13.3.12",
     "@angular/core": "^13.3.12",
     "@angular/forms": "^13.3.12",
-    "@angular/material": "^12.2.13",
+    "@angular/material": "^13.3.9",
     "@angular/platform-browser": "^13.3.12",
     "@angular/platform-browser-dynamic": "^13.3.12",
     "@angular/router": "^13.3.12",


### PR DESCRIPTION
## Description
Updated @angular/material version to 13.
Added demos for each of the major templateOptions supported by formly-input.
Added introduction story with brief description.
Updated stackblitz generation script to work with formly storybook demos.
Added additional demo to old SDS site to provide link to new storybook site. (This will not work until PR is merged, GH actions only run on changes to master)

## Motivation and Context
IAEMOD-9185

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="233" alt="Screen Shot 2023-01-20 at 5 39 42 PM" src="https://user-images.githubusercontent.com/72805180/213818011-6868d419-0584-48d8-a248-ea148180d327.png">
<img width="761" alt="Screen Shot 2023-01-20 at 5 39 55 PM" src="https://user-images.githubusercontent.com/72805180/213818023-4835c3a6-a018-478b-82d2-d976d93718e9.png">
<img width="747" alt="Screen Shot 2023-01-20 at 5 40 05 PM" src="https://user-images.githubusercontent.com/72805180/213818030-52bef790-8466-40d6-9623-e0ea7ec6cc2a.png">
<img width="1710" alt="Screen Shot 2023-01-20 at 5 40 31 PM" src="https://user-images.githubusercontent.com/72805180/213818047-55d1d1ab-5b7a-419c-a63a-05aa8a574d69.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

