### PR TITLE
IAEMOD-9187: Add link from old docs to Storybook

### DIFF
--- a/libs/documentation/src/lib/components/accordion/accordion.module.ts
+++ b/libs/documentation/src/lib/components/accordion/accordion.module.ts
@@ -65,7 +65,13 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, AccordionBasicModule, AccordionCardlistModule, AccordionLinkToSbModule],
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    AccordionBasicModule,
+    AccordionCardlistModule,
+    AccordionLinkToSbModule,
+  ],
 })
 export class AccordionModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/accordion/accordion.module.ts
+++ b/libs/documentation/src/lib/components/accordion/accordion.module.ts
@@ -10,9 +10,19 @@ import { ComponentWrapperComponent } from '../../shared/component-wrapper/compon
 import { AccordionBasicModule } from './demos/basic/accordion-basic.module';
 import { AccordionCardlistModule } from './demos/cardlist/accordion-cardlist.module';
 import { AccordionCardlist } from './demos/cardlist/accordion-cardlist.component';
+import { AccordionLinkToSbComponent } from './demos/link-to-sb/link-to-sb.component';
+import { AccordionLinkToSbModule } from './demos/link-to-sb/link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
+  linkToStorybook: {
+    title: 'New Demos',
+    type: AccordionLinkToSbComponent,
+    code: require('!!raw-loader!./demos/link-to-sb/link-to-sb.component'),
+    markup: require('!!raw-loader!./demos/link-to-sb/link-to-sb.component.html'),
+    module: require('!!raw-loader!./demos/link-to-sb/link-to-sb.module'),
+    path: 'libs/documentation/src/lib/components/accordion/demos/link-to-sb',
+  },
   basic: {
     title: 'Accordion',
     type: AccordionBasic,
@@ -55,7 +65,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, AccordionBasicModule, AccordionCardlistModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, AccordionBasicModule, AccordionCardlistModule, AccordionLinkToSbModule],
 })
 export class AccordionModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-autocomplete--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.html
@@ -1,5 +1,9 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
-<a href="https://gsa.github.io/sam-design-system/?path=/story/components-autocomplete--configurable">Link to Storybook</a>
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-autocomplete--configurable"
+  >Link to Storybook</a
+>

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-link-to-sb',
+  templateUrl: './link-to-sb.component.html',
+})
+export class AccordionLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './link-to-sb.component.html',
 })
 export class AccordionLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AccordionLinkToSbComponent } from './link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [AccordionLinkToSbComponent],
+  exports: [AccordionLinkToSbComponent],
+  bootstrap: [AccordionLinkToSbComponent],
+})
+export class AccordionLinkToSbModule { }

--- a/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/accordion/demos/link-to-sb/link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { AccordionLinkToSbComponent } from './link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [AccordionLinkToSbComponent],
   exports: [AccordionLinkToSbComponent],
   bootstrap: [AccordionLinkToSbComponent],
 })
-export class AccordionLinkToSbModule { }
+export class AccordionLinkToSbModule {}

--- a/libs/documentation/src/lib/components/button-group/button-group.module.ts
+++ b/libs/documentation/src/lib/components/button-group/button-group.module.ts
@@ -10,9 +10,19 @@ import { ButtonGroupBasic } from './demos/button-group-basic/button-group-basic.
 import { ButtonGroupBasicModule } from './demos/button-group-basic/button-group-basic.module';
 import { ButtonGroupDifferingLengths } from './demos/differinglengths/button-group-differing-lengths.component';
 import { ButtonGroupDifferingLengthsModule } from './demos/differinglengths/button-group-differing-lengths.module';
+import { ButtonGroupLinkToSbComponent } from './demos/button-group-link-to-sb/button-group-link-to-sb.component';
+import { ButtonGroupLinkToSbModule } from './demos/button-group-link-to-sb/button-group-link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
+  linkToStackblitz: {
+    title: 'New Demos',
+    type: ButtonGroupLinkToSbComponent,
+    code: require('!!raw-loader!./demos/button-group-link-to-sb/button-group-link-to-sb.component'),
+    markup: require('!!raw-loader!./demos/button-group-link-to-sb/button-group-link-to-sb.component.html'),
+    module: require('!!raw-loader!./demos/button-group-link-to-sb/button-group-link-to-sb.module'),
+    path: 'libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb',
+  },
   basic: {
     title: 'Button Groups',
     type: ButtonGroupBasic,
@@ -60,6 +70,7 @@ export const ROUTES = [
     DocumentationComponentsSharedModule,
     ButtonGroupBasicModule,
     ButtonGroupDifferingLengthsModule,
+    ButtonGroupLinkToSbModule
   ],
 })
 export class ButtonGroupModule {

--- a/libs/documentation/src/lib/components/button-group/button-group.module.ts
+++ b/libs/documentation/src/lib/components/button-group/button-group.module.ts
@@ -70,7 +70,7 @@ export const ROUTES = [
     DocumentationComponentsSharedModule,
     ButtonGroupBasicModule,
     ButtonGroupDifferingLengthsModule,
-    ButtonGroupLinkToSbModule
+    ButtonGroupLinkToSbModule,
   ],
 })
 export class ButtonGroupModule {

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.html
@@ -1,5 +1,9 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
-<a href="https://gsa.github.io/sam-design-system/?path=/story/components-button-group--configurable">Link to Storybook</a>
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-button-group--configurable"
+  >Link to Storybook</a
+>

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-button-group--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-button-group-link-to-sb',
+  templateUrl: './button-group-link-to-sb.component.html',
+})
+export class ButtonGroupLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './button-group-link-to-sb.component.html',
 })
 export class ButtonGroupLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { ButtonGroupLinkToSbComponent } from './button-group-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [ButtonGroupLinkToSbComponent],
   exports: [ButtonGroupLinkToSbComponent],
   bootstrap: [ButtonGroupLinkToSbComponent],
 })
-export class ButtonGroupLinkToSbModule { }
+export class ButtonGroupLinkToSbModule {}

--- a/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/button-group/demos/button-group-link-to-sb/button-group-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonGroupLinkToSbComponent } from './button-group-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [ButtonGroupLinkToSbComponent],
+  exports: [ButtonGroupLinkToSbComponent],
+  bootstrap: [ButtonGroupLinkToSbComponent],
+})
+export class ButtonGroupLinkToSbModule { }

--- a/libs/documentation/src/lib/components/date-pipe/date-pipe.module.ts
+++ b/libs/documentation/src/lib/components/date-pipe/date-pipe.module.ts
@@ -8,9 +8,19 @@ import { DocumentationComponentsSharedModule, DocumentationDemoList } from './..
 import { ComponentWrapperComponent } from './../../shared/component-wrapper/component-wrapper.component';
 import { DatePipeBasicComponent } from './demos/basic/date-pipe-basic/date-pipe-basic.component';
 import { DatePipeBasicModule } from './demos/basic/date-pipe-basic/date-pipe-basic.module';
+import { DatePipeLinkToSbModule } from './demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module';
+import { DatePipeLinkToSbComponent } from './demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component';
 
 declare var require: any;
 const DEMOS = {
+  linkToSb: {
+    title: 'New Demos',
+    type: DatePipeLinkToSbComponent,
+    code: require('!!raw-loader!./demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component'),
+    markup: require('!!raw-loader!./demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.html'),
+    module: require('!!raw-loader!./demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module'),
+    path: 'libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb',
+  },
   basic: {
     title: 'Date Pipe',
     type: DatePipeBasicComponent,
@@ -45,7 +55,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, DatePipeBasicModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, DatePipeBasicModule, DatePipeLinkToSbModule],
 })
 export class DatePipeModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-date-pipe--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.html
@@ -1,5 +1,7 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
 <a href="https://gsa.github.io/sam-design-system/?path=/story/components-date-pipe--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-date-pipe-link-to-sb',
+  templateUrl: './date-pipe-link-to-sb.component.html',
+})
+export class DatePipeLinkToSbComponent{
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.component.ts
@@ -4,8 +4,6 @@ import { Component, OnInit } from '@angular/core';
   selector: 'app-date-pipe-link-to-sb',
   templateUrl: './date-pipe-link-to-sb.component.html',
 })
-export class DatePipeLinkToSbComponent{
-
-  constructor() { }
-
+export class DatePipeLinkToSbComponent {
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { DatePipeLinkToSbComponent } from './date-pipe-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [DatePipeLinkToSbComponent],
   exports: [DatePipeLinkToSbComponent],
   bootstrap: [DatePipeLinkToSbComponent],
 })
-export class DatePipeLinkToSbModule { }
+export class DatePipeLinkToSbModule {}

--- a/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/date-pipe/demos/date-pipe-link-to-sb/date-pipe-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DatePipeLinkToSbComponent } from './date-pipe-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [DatePipeLinkToSbComponent],
+  exports: [DatePipeLinkToSbComponent],
+  bootstrap: [DatePipeLinkToSbComponent],
+})
+export class DatePipeLinkToSbModule { }

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.html
@@ -1,5 +1,7 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
 <a href="https://gsa.github.io/sam-design-system/?path=/story/components-expires--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-expires--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-expires-link-to-sb',
+  templateUrl: './expires-link-to-sb.component.html',
+})
+export class ExpiresLinkToSbComponent{
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.component.ts
@@ -4,8 +4,6 @@ import { Component, OnInit } from '@angular/core';
   selector: 'app-expires-link-to-sb',
   templateUrl: './expires-link-to-sb.component.html',
 })
-export class ExpiresLinkToSbComponent{
-
-  constructor() { }
-
+export class ExpiresLinkToSbComponent {
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { ExpiresLinkToSbComponent } from './expires-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [ExpiresLinkToSbComponent],
   exports: [ExpiresLinkToSbComponent],
   bootstrap: [ExpiresLinkToSbComponent],
 })
-export class ExpiresLinkToSbModule { }
+export class ExpiresLinkToSbModule {}

--- a/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/expires/demos/expires-link-to-sb/expires-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ExpiresLinkToSbComponent } from './expires-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [ExpiresLinkToSbComponent],
+  exports: [ExpiresLinkToSbComponent],
+  bootstrap: [ExpiresLinkToSbComponent],
+})
+export class ExpiresLinkToSbModule { }

--- a/libs/documentation/src/lib/components/expires/expires.module.ts
+++ b/libs/documentation/src/lib/components/expires/expires.module.ts
@@ -7,10 +7,20 @@ import { DocumentationExamplesPage } from '../shared/examples-page/examples.comp
 import { DocumentationSourcePage } from '../shared/source-page/source.component';
 import { ExpiresBasicComponent } from './demos/basic/expires-basic.component';
 import { ExpiresBasicModule } from './demos/basic/expires-basic.module';
+import { ExpiresLinkToSbComponent } from './demos/expires-link-to-sb/expires-link-to-sb.component';
+import { ExpiresLinkToSbModule } from './demos/expires-link-to-sb/expires-link-to-sb.module';
 
 export declare var require: any;
 
 const DEMOS = {
+  linkToSb: {
+    title: 'New Demos',
+    type: ExpiresLinkToSbComponent,
+    code: require('!!raw-loader!./demos/expires-link-to-sb/expires-link-to-sb.component'),
+    module: require('!!raw-loader!./demos/expires-link-to-sb/expires-link-to-sb.module'),
+    markup: require('!!raw-loader!./demos/expires-link-to-sb/expires-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/expires/demos/expires-link-to-sb',
+  },
   basic: {
     title: 'Expires Directive',
     type: ExpiresBasicComponent,
@@ -44,7 +54,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, ExpiresBasicModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, ExpiresBasicModule, ExpiresLinkToSbModule],
 })
 export class ExpiresModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.html
@@ -1,5 +1,9 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
-<a href="https://gsa.github.io/sam-design-system/?path=/story/components-external-link--configurable">Link to Storybook</a>
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-external-link--configurable"
+  >Link to Storybook</a
+>

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-external-link--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './external-link-link-to-sb.component.html',
 })
 export class ExternalLinkLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-external-link-link-to-sb',
+  templateUrl: './external-link-link-to-sb.component.html',
+})
+export class ExternalLinkLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { ExternalLinkLinkToSbComponent } from './external-link-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [ExternalLinkLinkToSbComponent],
   bootstrap: [ExternalLinkLinkToSbComponent],
   exports: [ExternalLinkLinkToSbComponent],
 })
-export class ExternalLinkLinkToSbModule { }
+export class ExternalLinkLinkToSbModule {}

--- a/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb/external-link-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ExternalLinkLinkToSbComponent } from './external-link-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [ExternalLinkLinkToSbComponent],
+  bootstrap: [ExternalLinkLinkToSbComponent],
+  exports: [ExternalLinkLinkToSbComponent],
+})
+export class ExternalLinkLinkToSbModule { }

--- a/libs/documentation/src/lib/components/external-link/external-link.module.ts
+++ b/libs/documentation/src/lib/components/external-link/external-link.module.ts
@@ -7,10 +7,20 @@ import { DocumentationExamplesPage } from '../shared/examples-page/examples.comp
 import { DocumentationSourcePage } from '../shared/source-page/source.component';
 import { ExternalLinkBasicComponent } from './demos/basic/external-link-basic.component';
 import { ExternalLinkBasicModule } from './demos/basic/external-link-basic.module';
+import { ExternalLinkLinkToSbComponent } from './demos/external-link-link-to-sb/external-link-link-to-sb.component';
+import { ExternalLinkLinkToSbModule } from './demos/external-link-link-to-sb/external-link-link-to-sb.module';
 
 export declare var require: any;
 
 const DEMOS = {
+  linkToSb: {
+    title: 'New Demos',
+    type: ExternalLinkLinkToSbComponent,
+    code: require('!!raw-loader!./demos/external-link-link-to-sb/external-link-link-to-sb.component'),
+    module: require('!!raw-loader!./demos/external-link-link-to-sb/external-link-link-to-sb.module'),
+    markup: require('!!raw-loader!./demos/external-link-link-to-sb/external-link-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/external-link/demos/external-link-link-to-sb',
+  },
   basic: {
     title: 'External Link',
     type: ExternalLinkBasicComponent,
@@ -44,7 +54,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, ExternalLinkBasicModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, ExternalLinkBasicModule, ExternalLinkLinkToSbModule],
 })
 export class ExternalLinkModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-search--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.html
@@ -1,5 +1,7 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
 <a href="https://gsa.github.io/sam-design-system/?path=/story/components-search--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './search-link-to-sb.component.html',
 })
 export class SearchLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-search-link-to-sb',
+  templateUrl: './search-link-to-sb.component.html',
+})
+export class SearchLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { SearchLinkToSbComponent } from './search-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [SearchLinkToSbComponent],
   exports: [SearchLinkToSbComponent],
   bootstrap: [SearchLinkToSbComponent],
 })
-export class SearchLinkToSbModule { }
+export class SearchLinkToSbModule {}

--- a/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/search/demos/search-link-to-sb/search-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SearchLinkToSbComponent } from './search-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [SearchLinkToSbComponent],
+  exports: [SearchLinkToSbComponent],
+  bootstrap: [SearchLinkToSbComponent],
+})
+export class SearchLinkToSbModule { }

--- a/libs/documentation/src/lib/components/search/search.module.ts
+++ b/libs/documentation/src/lib/components/search/search.module.ts
@@ -66,7 +66,13 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, SearchBasicModule, SearchOptionalModule, SearchLinkToSbModule],
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    SearchBasicModule,
+    SearchOptionalModule,
+    SearchLinkToSbModule,
+  ],
 })
 export class SearchModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/search/search.module.ts
+++ b/libs/documentation/src/lib/components/search/search.module.ts
@@ -11,9 +11,19 @@ import { SearchBasicModule } from './demos/basic/search-basic.module';
 import { SearchBasic } from './demos/basic/search-basic.component';
 import { SearchOptional } from './demos/optional/search-optional.component';
 import { SearchOptionalModule } from './demos/optional/search-optional.module';
+import { SearchLinkToSbComponent } from './demos/search-link-to-sb/search-link-to-sb.component';
+import { SearchLinkToSbModule } from './demos/search-link-to-sb/search-link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
+  linkToSb: {
+    title: 'New Demos',
+    type: SearchLinkToSbComponent,
+    code: require('!!raw-loader!./demos/search-link-to-sb/search-link-to-sb.component'),
+    module: require('!!raw-loader!./demos/search-link-to-sb/search-link-to-sb.module'),
+    markup: require('!!raw-loader!./demos/search-link-to-sb/search-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/search/demo/ssearch-link-to-sb',
+  },
   basic: {
     title: 'Basic Search ',
     type: SearchBasic,
@@ -56,7 +66,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, SearchBasicModule, SearchOptionalModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, SearchBasicModule, SearchOptionalModule, SearchLinkToSbModule],
 })
 export class SearchModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.html
@@ -1,0 +1,5 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-popover--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.html
@@ -1,5 +1,7 @@
 <p>
-  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this component, interact with the inputs of this component, see basic examples of this component in use and find a link to edit these basic examples in StackBlitz.
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
 </p>
 
 <a href="https://gsa.github.io/sam-design-system/?path=/story/components-popover--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.ts
@@ -1,0 +1,11 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-popover-link-to-sb',
+  templateUrl: './popover-link-to-sb.component.html',
+})
+export class PopoverLinkToSbComponent {
+
+  constructor() { }
+
+}

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.component.ts
@@ -5,7 +5,5 @@ import { Component, OnInit } from '@angular/core';
   templateUrl: './popover-link-to-sb.component.html',
 })
 export class PopoverLinkToSbComponent {
-
-  constructor() { }
-
+  constructor() {}
 }

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PopoverLinkToSbComponent } from './popover-link-to-sb.component';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [PopoverLinkToSbComponent],
+  bootstrap: [PopoverLinkToSbComponent],
+  exports: [PopoverLinkToSbComponent],
+})
+export class PopoverLinkToSbModule { }

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/popover-link-to-sb/popover-link-to-sb.module.ts
@@ -3,11 +3,9 @@ import { CommonModule } from '@angular/common';
 import { PopoverLinkToSbComponent } from './popover-link-to-sb.component';
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
+  imports: [CommonModule],
   declarations: [PopoverLinkToSbComponent],
   bootstrap: [PopoverLinkToSbComponent],
   exports: [PopoverLinkToSbComponent],
 })
-export class PopoverLinkToSbModule { }
+export class PopoverLinkToSbModule {}

--- a/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
@@ -9,9 +9,19 @@ import { PopupBasicModule } from './demos/basic/popup-basic.module';
 import { PopupBasic } from './demos/basic/popup-basic.component';
 import { TooltipBasic } from './demos/tooltip/tooltip-basic.component';
 import { TooltipBasicModule } from './demos/tooltip/tooltip-basic.module';
+import { PopoverLinkToSbComponent } from './demos/popover-link-to-sb/popover-link-to-sb.component';
+import { PopoverLinkToSbModule } from './demos/popover-link-to-sb/popover-link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
+  linkToSb: {
+    title: 'New Popover Demos',
+    type: PopoverLinkToSbComponent,
+    code: require('!!raw-loader!./demos/popover-link-to-sb/popover-link-to-sb.component'),
+    module: require('!!raw-loader!./demos/popover-link-to-sb/popover-link-to-sb.module'),
+    markup: require('!!raw-loader!./demos/popover-link-to-sb/popover-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/popup/demos/popover-link-to-sb',
+  },
   tooltip: {
     title: 'Tooltip',
     type: TooltipBasic,
@@ -53,7 +63,7 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, PopupBasicModule, TooltipBasicModule],
+  imports: [CommonModule, DocumentationComponentsSharedModule, PopupBasicModule, TooltipBasicModule, PopoverLinkToSbModule],
 })
 export class PopupModule {
   constructor(demoList: DocumentationDemoList) {

--- a/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
@@ -63,7 +63,13 @@ export const ROUTES = [
 ];
 
 @NgModule({
-  imports: [CommonModule, DocumentationComponentsSharedModule, PopupBasicModule, TooltipBasicModule, PopoverLinkToSbModule],
+  imports: [
+    CommonModule,
+    DocumentationComponentsSharedModule,
+    PopupBasicModule,
+    TooltipBasicModule,
+    PopoverLinkToSbModule,
+  ],
 })
 export class PopupModule {
   constructor(demoList: DocumentationDemoList) {


### PR DESCRIPTION
## Description
Adds links from old SDS demo site to new storybook site for demos that have already been transferred. Components which have not yet been migrated will have this link added as a part of those migrations

## Motivation and Context
IAEMOD-9187

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="998" alt="Screen Shot 2023-01-23 at 12 45 12 PM" src="https://user-images.githubusercontent.com/72805180/214111543-e5ab67bb-17d2-4f1b-84ea-7798af81f901.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

