### PR TITLE
Fix video player

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -129,7 +129,7 @@
               "node_modules/highlight.js/styles/vs.css"
             ],
             "scripts": [
-              "node_modules/marked/lib/marked.cjs",
+              "node_modules/marked/marked.min.js",
               "node_modules/accessible-html5-video-player/js/px-video.js",
               "node_modules/accessible-html5-video-player/js/strings.js"
             ],

--- a/libs/packages/components/src/lib/video-player/video-player.component.ts
+++ b/libs/packages/components/src/lib/video-player/video-player.component.ts
@@ -94,7 +94,7 @@ export class SdsVideoPlayerComponent implements AfterViewInit, OnChanges, OnInit
   }
 
   ngOnChanges(changes) {
-    if (changes && changes.crossorigin) {
+    if (this.video && changes && changes.crossorigin) {
       const id = this.video.nativeElement;
       if (id) {
         id.setAttribute('crossorigin', this.crossorigin);


### PR DESCRIPTION
## Description
In the course of adding storybook, compodoc was updated to 1.1.19. This version contains a dependency on marked 4.x.x. Somewhere between the old version and 4.x.x, marked/lib/marked.js was removed and replaced by some other formats of that file. When updating, the .cjs version was used. However, according to marked's changelong, marked/marked.min.js should be used as a drop in replacement.

Additionally, the way crossorigin is currently being set does not take into account the scenario on the first load when video has not been loaded, and so it errors.

## Motivation and Context
First issues was a show-stopper, the component will not load in the current version of master.
Second issue, is more about cleaning up the console. crossorigin is applied, but that error is generated.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
Crossorigin error:
<img width="1728" alt="Screen Shot 2023-01-26 at 4 16 30 AM" src="https://user-images.githubusercontent.com/72805180/214800878-25e3188e-1493-4c29-8300-1862adb1d5ca.png">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

