### PR TITLE
IAEMOD-9759: Update tooltip + Add demos

### DIFF
--- a/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.component.html
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.component.html
@@ -1,0 +1,7 @@
+<p>
+  We have migrated this demo to Storybook. In storybook you will be able to get basic information for where to use this
+  component, interact with the inputs of this component, see basic examples of this component in use and find a link to
+  edit these basic examples in StackBlitz.
+</p>
+
+<a href="https://gsa.github.io/sam-design-system/?path=/story/components-tooltip--configurable">Link to Storybook</a>

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.component.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-tooltip-link-to-sb',
+  templateUrl: './tooltip-link-to-sb.component.html',
+})
+export class TooltipLinkToSbComponent {
+  constructor() {}
+}

--- a/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/demos/tooltip-link-to-sb/tooltip-link-to-sb.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipLinkToSbComponent } from './tooltip-link-to-sb.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [TooltipLinkToSbComponent],
+  bootstrap: [TooltipLinkToSbComponent],
+  exports: [TooltipLinkToSbComponent],
+})
+export class TooltipLinkToSbModule {}

--- a/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
+++ b/libs/documentation/src/lib/components/tooltip-popover/tooltip-popover.module.ts
@@ -11,6 +11,8 @@ import { TooltipBasic } from './demos/tooltip/tooltip-basic.component';
 import { TooltipBasicModule } from './demos/tooltip/tooltip-basic.module';
 import { PopoverLinkToSbComponent } from './demos/popover-link-to-sb/popover-link-to-sb.component';
 import { PopoverLinkToSbModule } from './demos/popover-link-to-sb/popover-link-to-sb.module';
+import { TooltipLinkToSbComponent } from './demos/tooltip-link-to-sb/tooltip-link-to-sb.component';
+import { TooltipLinkToSbModule } from './demos/tooltip-link-to-sb/tooltip-link-to-sb.module';
 
 declare var require: any;
 const DEMOS = {
@@ -21,6 +23,14 @@ const DEMOS = {
     module: require('!!raw-loader!./demos/popover-link-to-sb/popover-link-to-sb.module'),
     markup: require('!!raw-loader!./demos/popover-link-to-sb/popover-link-to-sb.component.html'),
     path: 'libs/documentation/src/lib/components/popup/demos/popover-link-to-sb',
+  },
+  tooltipLinkToSb: {
+    title: 'New Tooltip Demos',
+    type: TooltipLinkToSbComponent,
+    code: require('!!raw-loader!./demos/tooltip-link-to-sb/tooltip-link-to-sb.component'),
+    module: require('!!raw-loader!./demos/tooltip-link-to-sb/tooltip-link-to-sb.module'),
+    markup: require('!!raw-loader!./demos/tooltip-link-to-sb/tooltip-link-to-sb.component.html'),
+    path: 'libs/documentation/src/lib/components/popup/demos/tooltip-link-to-sb',
   },
   tooltip: {
     title: 'Tooltip',
@@ -69,6 +79,7 @@ export const ROUTES = [
     PopupBasicModule,
     TooltipBasicModule,
     PopoverLinkToSbModule,
+    TooltipLinkToSbModule,
   ],
 })
 export class PopupModule {

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.component.html
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.component.html
@@ -1,0 +1,5 @@
+<div style="margin: 2rem;">
+  <button class="usa-button usa-button--base" [sdsTooltip]="tooltipContent" [position]="position">
+    Hover to Show Tooltip
+  </button>
+</div>

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.component.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'sds-tooltip-configurable',
+  templateUrl: './tooltip-configurable.component.html',
+})
+export class TooltipConfigurableComponent {
+  @Input('position')
+  position: 'top' | 'bottom' | 'right' | 'left' = 'top';
+
+  @Input('tooltipContent')
+  tooltipContent: string;
+
+  constructor() {}
+}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.module.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-configurable/tooltip-configurable.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipConfigurableComponent } from './tooltip-configurable.component';
+import { SdsTooltipModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsTooltipModule],
+  declarations: [TooltipConfigurableComponent],
+  exports: [TooltipConfigurableComponent],
+  bootstrap: [TooltipConfigurableComponent],
+})
+export class TooltipConfigurableModule {}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.component.html
@@ -1,0 +1,4 @@
+<p>
+  Tooltip allows additional information to be displayed when a user "focuses" on an element that this directive is
+  applied to.
+</p>

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.component.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-tooltip-introduction',
+  templateUrl: './tooltip-introduction.component.html',
+})
+export class TooltipIntroductionComponent {
+  constructor() {}
+}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.module.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-introduction/tooltip-introduction.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipIntroductionComponent } from './tooltip-introduction.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [TooltipIntroductionComponent],
+  exports: [TooltipIntroductionComponent],
+  bootstrap: [TooltipIntroductionComponent],
+})
+export class TooltipIntroductionModule {}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.component.html
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.component.html
@@ -1,0 +1,14 @@
+<div style="margin: 1rem; margin-left: 15rem;">
+  <button class="usa-button usa-button--base" [sdsTooltip]="'Tooltip on left'" [position]="'left'">
+    Tooltip on left
+  </button>
+  <button class="usa-button usa-button--base" [sdsTooltip]="'Tooltip on top'" [position]="'top'">
+    Tooltip on top
+  </button>
+  <button class="usa-button usa-button--base" [sdsTooltip]="'Tooltip on bottom'" [position]="'bottom'">
+    Tooltip on bottom
+  </button>
+  <button class="usa-button usa-button--base" [sdsTooltip]="'Tooltip on right'" [position]="'right'">
+    Tooltip on right
+  </button>
+</div>

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.component.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-tooltip-position',
+  templateUrl: './tooltip-position.component.html',
+})
+export class TooltipPositionComponent {
+  constructor() {}
+}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.module.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-position/tooltip-position.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipPositionComponent } from './tooltip-position.component';
+import { SdsTooltipModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsTooltipModule],
+  declarations: [TooltipPositionComponent],
+  exports: [TooltipPositionComponent],
+  bootstrap: [TooltipPositionComponent],
+})
+export class TooltipPositionModule {}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.component.html
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.component.html
@@ -1,0 +1,10 @@
+<p>Content displayed in a tooltip can be a string.</p>
+<button [sdsTooltip]="'Content'" [position]="'bottom'" class="usa-button usa-button--base" tabindex="0">
+  String binding
+</button>
+
+<p>Content displayed in a tooltip can also be HTML elements</p>
+<p #tipContent>Hello, <b>World</b>!</p>
+<button [sdsTooltip]="tipContent" [position]="'bottom'" class="usa-button usa-button--base" tabindex="0">
+  HTML binding
+</button>

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.component.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-tooltip-sdsTooltip',
+  templateUrl: './tooltip-sdsTooltip.component.html',
+})
+export class TooltipSdsTooltipComponent {
+  constructor() {}
+}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.module.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip-sdsTooltip/tooltip-sdsTooltip.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipSdsTooltipComponent } from './tooltip-sdsTooltip.component';
+import { SdsTooltipModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsTooltipModule],
+  declarations: [TooltipSdsTooltipComponent],
+  exports: [TooltipSdsTooltipComponent],
+  bootstrap: [TooltipSdsTooltipComponent],
+})
+export class TooltipSdsTooltipModule {}

--- a/libs/documentation/src/lib/storybook/tooltip/tooltip.stories.ts
+++ b/libs/documentation/src/lib/storybook/tooltip/tooltip.stories.ts
@@ -1,0 +1,106 @@
+import { CommonModule } from '@angular/common';
+import { SdsTooltipDirective } from '@gsa-sam/components';
+import { moduleMetadata, Meta, Story } from '@storybook/angular';
+import { generateConfig, generateStackblitzLink } from 'libs/documentation/src/sandbox/sandbox-utils';
+import { TooltipConfigurableModule } from './tooltip-configurable/tooltip-configurable.module';
+import { TooltipIntroductionModule } from './tooltip-introduction/tooltip-introduction.module';
+import { TooltipPositionModule } from './tooltip-position/tooltip-position.module';
+import { TooltipSdsTooltipModule } from './tooltip-sdsTooltip/tooltip-sdsTooltip.module';
+
+const disable = {
+  table: {
+    disable: true,
+  },
+};
+
+export default {
+  title: 'Components/Tooltip',
+  component: SdsTooltipDirective,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CommonModule,
+        TooltipIntroductionModule,
+        TooltipConfigurableModule,
+        TooltipSdsTooltipModule,
+        TooltipPositionModule,
+      ],
+    }),
+  ],
+  argTypes: {
+    _sdsTooltip: disable,
+    _tooltipShowing: disable,
+    sdsTooltipDiv: disable,
+    hideTooltip: disable,
+    ngAfterViewInit: disable,
+    onBlur: disable,
+    onFocus: disable,
+    onKeyUp: disable,
+    onMouseEnter: disable,
+    onMouseLeave: disable,
+    showTooltip: disable,
+    clearAndReplacePosition: disable,
+    clearAndReplaceTooltipContent: disable,
+    ngOnChanges: disable,
+    position: {
+      options: ['top', 'bottom', 'left', 'right'],
+      control: { type: 'select' },
+    },
+  },
+} as Meta;
+
+export const Introduction: Story = (args) => ({
+  template: '<sds-tooltip-introduction></sds-tooltip-introduction>',
+  props: args,
+});
+Introduction.parameters = {
+  options: { showPanel: false },
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: { disabled: true },
+};
+
+export const Configurable: Story = (args) => ({
+  template: '<sds-tooltip-configurable [position]=position [tooltipContent]=sdsTooltip></sds-tooltip-configurable>',
+  props: args,
+});
+Configurable.args = {
+  sdsTooltip: 'tooltip content',
+};
+Configurable.parameters = {
+  actions: { disabled: true },
+  preview: { disabled: true },
+};
+
+export const Position: Story = (args) => ({
+  template: `<sds-tooltip-position></sds-tooltip-position>`,
+  props: args,
+});
+Position.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig('storybook/tooltip/tooltip-position', 'TooltipPositionModule', 'sds-tooltip-position'),
+  stackblitzLink: generateStackblitzLink('tooltip', 'position'),
+};
+
+export const SdsTooltip: Story = (args) => ({
+  template: `<sds-tooltip-sdsTooltip></sds-tooltip-sdsTooltip>`,
+  props: args,
+});
+SdsTooltip.parameters = {
+  controls: {
+    disabled: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disabled: true },
+  preview: generateConfig('storybook/tooltip/tooltip-sdsTooltip', 'TooltipSdsTooltipModule', 'sds-tooltip-sdsTooltip'),
+  stackblitzLink: generateStackblitzLink('tooltip', 'sdsTooltip'),
+};
+
+export const __namedExportsOrder = ['Introduction', 'Configurable', 'Position', 'SdsTooltip'];

--- a/libs/packages/components/src/lib/tooltip/tooltip.directive.ts
+++ b/libs/packages/components/src/lib/tooltip/tooltip.directive.ts
@@ -1,10 +1,20 @@
-import { AfterViewInit, Directive, ElementRef, HostListener, Input, Renderer2, TemplateRef } from '@angular/core';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  Renderer2,
+  SimpleChanges,
+  TemplateRef,
+} from '@angular/core';
 
 @Directive({
   selector: '[sdsTooltip]',
   exportAs: 'sdsTooltip',
 })
-export class SdsTooltipDirective implements AfterViewInit {
+export class SdsTooltipDirective implements AfterViewInit, OnChanges {
   private _sdsTooltip: string | TemplateRef<any> | HTMLDivElement;
   sdsTooltipDiv: HTMLElement;
 
@@ -80,5 +90,28 @@ export class SdsTooltipDirective implements AfterViewInit {
 
   get sdsTooltip(): string | TemplateRef<any> | HTMLDivElement {
     return this._sdsTooltip;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.position) {
+      this.clearAndReplacePosition(changes.position.currentValue, changes.position.previousValue);
+    }
+    if (changes.sdsTooltip && !changes.sdsTooltip.firstChange) {
+      this.clearAndReplaceTooltipContent(this.sdsTooltip);
+    }
+  }
+
+  clearAndReplacePosition(newPosition: string, oldPosition?: string) {
+    if (oldPosition) {
+      this.renderer.removeClass(this.sdsTooltipDiv, oldPosition);
+    }
+    this.renderer.setAttribute(this.sdsTooltipDiv, 'data-position', newPosition);
+    this.renderer.addClass(this.sdsTooltipDiv, newPosition);
+  }
+
+  clearAndReplaceTooltipContent(newContent) {
+    const toRemove = this.sdsTooltipDiv.querySelector('.tooltip');
+    this.renderer.removeChild(toRemove.parentNode, toRemove);
+    this.renderer.appendChild(this.sdsTooltipDiv, newContent);
   }
 }


### PR DESCRIPTION
## Description
Add tooltip demos to SB
Add link from SDS docs to SB
Updated tooltip to allow changes in the inputs to be reflected in tooltip without having to delete and recreate the element which the tooltip was applied. Due to how the current version of tooltip works updating an input, position for example, will not result in the position of the tooltip changing

## Motivation and Context
IAEMOD-9759

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

<img width="791" alt="Screen Shot 2023-02-09 at 9 13 49 AM" src="https://user-images.githubusercontent.com/72805180/217838431-7cdcb8bd-319e-4d06-ba22-5c51601d6007.png">

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

