### PR TITLE
Adjust demos to use info toasts

### DIFF
--- a/libs/documentation/src/lib/storybook/toasts/toasts-configurable/toasts-configurable.component.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-configurable/toasts-configurable.component.ts
@@ -12,7 +12,7 @@ export class ToastsConfigurableComponent {
   toastMessage: string = 'Test Message';
 
   @Input()
-  toastType: 'General' | 'Success' | 'Info' | 'Warning' | 'Error';
+  toastType: 'Success' | 'Info' | 'Warning' | 'Error';
 
   @Input()
   set toastTimeout(timeout: number) {
@@ -43,9 +43,6 @@ export class ToastsConfigurableComponent {
 
   showToast() {
     switch (this.toastType) {
-      case 'General':
-        this.toastr.show(this.toastMessage, '');
-        break;
       case 'Success':
         this.toastr.success(this.toastMessage, '');
         break;

--- a/libs/documentation/src/lib/storybook/toasts/toasts-message/toasts-message.component.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-message/toasts-message.component.ts
@@ -24,9 +24,9 @@ export class ToastsMessageComponent {
   }
 
   showPlainTextMessage() {
-    this.toastr.show('Plain Toast Message', '');
+    this.toastr.info('Plain Toast Message', '');
   }
   showHTMLMessage() {
-    this.toastr.show('<i>HTML Toast Message</i>', '');
+    this.toastr.info('<i>HTML Toast Message</i>', '');
   }
 }

--- a/libs/documentation/src/lib/storybook/toasts/toasts-prevent-duplicates/toasts-prevent-duplicates.component.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-prevent-duplicates/toasts-prevent-duplicates.component.ts
@@ -22,6 +22,6 @@ export class ToastsPreventDuplicatesComponent {
   }
 
   showMessageWithoutDuplicates() {
-    this.toastr.show('This Message Will Not Duplicate', '');
+    this.toastr.info('This Message Will Not Duplicate', '');
   }
 }

--- a/libs/documentation/src/lib/storybook/toasts/toasts-timeout/toasts-timeout.component.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-timeout/toasts-timeout.component.ts
@@ -23,10 +23,10 @@ export class ToastsTimeoutComponent {
   showTwoSecondTimeoutMessage() {
     this.options.disableTimeOut = false;
     this.options.timeOut = 2000;
-    this.toastr.show('This Message Will Disappear In 2 Seconds', '');
+    this.toastr.info('This Message Will Disappear In 2 Seconds', '');
   }
   showNoTimeoutMessage() {
     this.options.disableTimeOut = true;
-    this.toastr.show('This Message Will Not Timeout', '');
+    this.toastr.info('This Message Will Not Timeout', '');
   }
 }

--- a/libs/documentation/src/lib/storybook/toasts/toasts-type/toasts-type.component.html
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-type/toasts-type.component.html
@@ -1,4 +1,3 @@
-<button class="usa-button" (click)="showGeneralToast()">General Toast</button>
 <button class="usa-button" (click)="showSuccessToast()">Success Toast</button>
 <button class="usa-button" (click)="showInfoToast()">Info Toast</button>
 <button class="usa-button" (click)="showWarningToast()">Warning Toast</button>

--- a/libs/documentation/src/lib/storybook/toasts/toasts-type/toasts-type.component.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts-type/toasts-type.component.ts
@@ -19,10 +19,6 @@ export class ToastsTypeComponent {
 
     this.options.closeButton = true;
   }
-
-  showGeneralToast() {
-    this.toastr.show('A General Toast Message', '');
-  }
   showSuccessToast() {
     this.toastr.success('A Success Toast Message', '');
   }

--- a/libs/documentation/src/lib/storybook/toasts/toasts.stories.ts
+++ b/libs/documentation/src/lib/storybook/toasts/toasts.stories.ts
@@ -30,7 +30,7 @@ export default {
   ],
   argTypes: {
     toastType: {
-      options: ['General', 'Success', 'Info', 'Warning', 'Error'],
+      options: ['Success', 'Info', 'Warning', 'Error'],
       control: { type: 'select' },
       table: {
         type: { summary: 'select' },


### PR DESCRIPTION
## Description
Per demo feedback, have updated demos to use info toasts.

## Motivation and Context

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

