### PR TITLE
Update sam package versions to fix stackblitz issues

### DIFF
--- a/misc/generate-stackblitzes.ts
+++ b/misc/generate-stackblitzes.ts
@@ -16,9 +16,9 @@ let dependencies = packageJson.dependencies;
 // Locking version at 11.0.3 - issue with stackblitz is that it does not pick up newly released npm modules for weeks
 const samDependencies = {
   '@gsa-sam/layouts': '12.0.0',
-  '@gsa-sam/components': '13.0.6',
-  '@gsa-sam/sam-formly': '13.0.6',
-  '@gsa-sam/sam-material-extensions': '13.0.6',
+  '@gsa-sam/components': '15.0.0',
+  '@gsa-sam/sam-formly': '15.0.0',
+  '@gsa-sam/sam-material-extensions': '15.0.0',
 };
 
 dependencies = { ...dependencies, ...samDependencies };


### PR DESCRIPTION
## Description
Stackblitz demos were broken in a previous version due to SAM packages used in demos not being the latest version. This PR updates the version used in stackblitz

## Motivation and Context
Stackblitz demos were broken in a previous version due to SAM packages used in demos not being the latest version

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

