### PR TITLE
1329: Fix issue with stepper

### DIFF
--- a/libs/documentation/src/test.ts
+++ b/libs/documentation/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'core-js/es7/reflect';
+import 'core-js/es/reflect';
 import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.component.spec.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.component.spec.ts
@@ -212,8 +212,8 @@ describe('SdsStepperComponent', () => {
 
   it('Should create with expected steps', () => {
     expect(stepper).toBeDefined();
-    expect(stepper.stepTemplates.toArray()[1].children.length).toEqual(0);
-    expect(stepper.flatSteps.length).toEqual(2);
+    expect(stepper.stepTemplates.toArray()[1].children.length).toEqual(1);
+    expect(stepper.flatSteps.length).toEqual(3);
     expect(stepper.currentStepId).toEqual('step1');
 
     const validSteps = fixture.debugElement.queryAll(By.css('.bi sds-check'));
@@ -262,7 +262,7 @@ describe('SdsStepperComponent', () => {
     'Should jump to step 1 when clicking from side navigation',
     waitForAsync(() => {
       const sidenavLinks = fixture.debugElement.queryAll(By.css('li a'));
-      sidenavLinks[2]?.triggerEventHandler('click', null);
+      sidenavLinks[2].triggerEventHandler('click', null);
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         expect(stepper.currentStepId).toEqual('step1');

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
@@ -47,7 +47,7 @@ export class SdsStepComponent {
   /**
    * References to Any children this step might contain
    */
-  @ContentChildren('SdsStepComponent') children: QueryList<SdsStepComponent>;
+  @ContentChildren(SdsStepComponent) children: QueryList<SdsStepComponent>;
 
   /**
    * Content of step - either a formly field or custome template

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
@@ -47,7 +47,7 @@ export class SdsStepComponent {
   /**
    * References to Any children this step might contain
    */
-  @ContentChildren(SdsStepComponent) children: QueryList<SdsStepComponent>;
+  @ContentChildren(forwardRef(() => SdsStepComponent)) children: QueryList<SdsStepComponent>;
 
   /**
    * Content of step - either a formly field or custome template


### PR DESCRIPTION
## Description
This PR fixes an error where sub-steps were not being loaded. Also fixes a couple tests that were changed when this bug was introduced. And addresses one additional test issue.

## Motivation and Context
Addresses #1329 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
v15.0.2:
<img width="348" alt="Screenshot 2023-10-16 at 3 16 52 PM" src="https://github.com/GSA/sam-design-system/assets/72805180/26cfc923-ba42-4ee3-9488-0f5be8192147">

After applying this PR:
<img width="348" alt="Screenshot 2023-10-16 at 3 13 56 PM" src="https://github.com/GSA/sam-design-system/assets/72805180/b9c8d046-6b48-4683-92c2-d82ec548f297">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

