### PR TITLE
Add Missing Demos

### DIFF
--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.component.html
@@ -18,7 +18,3 @@
   The rich text editor component can be passed a formControl for use in reactive forms. Subscribing to
   <code>valueChanges</code> allows developers to get updates as users change value of the rich text editor.
 </p>
-
-<sds-rich-text [formControl]="fc" [maxHeight]="10"></sds-rich-text>
-
-<p>Rich Text Editor Value: {{ fc.value }}</p>

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.component.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'sds-rich-text-editor-introduction',
+  templateUrl: './rich-text-editor-introduction.component.html',
+})
+export class RichTextEditorIntroductionComponent {}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.module.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-introduction/rich-text-editor-introduction.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RichTextEditorIntroductionComponent } from './rich-text-editor-introduction.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [RichTextEditorIntroductionComponent],
+  exports: [RichTextEditorIntroductionComponent],
+  bootstrap: [RichTextEditorIntroductionComponent],
+})
+export class RichTextEditorIntroductionModule {}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.component.html
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.component.html
@@ -1,0 +1,5 @@
+<div style="padding-top: 5rem;">
+  <sds-rich-text [formControl]="fc" [maxHeight]="6"></sds-rich-text>
+
+  <p>Rich Text Editor Value: {{ fc.value }}</p>
+</div>

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.component.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { UntypedFormControl } from '@angular/forms';
+
+@Component({
+  selector: 'sds-rich-text-editor-max-height',
+  templateUrl: './rich-text-editor-max-height.component.html',
+})
+export class RichTextEditorMaxHeightComponent {
+  public data = '';
+  fc: UntypedFormControl = new UntypedFormControl('<p>this is a test</p>');
+}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.module.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-max-height/rich-text-editor-max-height.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RichTextEditorMaxHeightComponent } from './rich-text-editor-max-height.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SdsRichTextModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsRichTextModule, FormsModule, ReactiveFormsModule],
+  declarations: [RichTextEditorMaxHeightComponent],
+  bootstrap: [RichTextEditorMaxHeightComponent],
+  exports: [RichTextEditorMaxHeightComponent],
+})
+export class RichTextEditorMaxHeightModule {}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.component.html
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.component.html
@@ -1,0 +1,5 @@
+<div style="padding-top: 5rem;">
+  <sds-rich-text [formControl]="fc" [minHeight]="10"></sds-rich-text>
+
+  <p>Rich Text Editor Value: {{ fc.value }}</p>
+</div>

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.component.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { UntypedFormControl } from '@angular/forms';
+
+@Component({
+  selector: 'sds-rich-text-editor-min-height',
+  templateUrl: './rich-text-editor-min-height.component.html',
+})
+export class RichTextEditorMinHeightComponent {
+  public data = '';
+  fc: UntypedFormControl = new UntypedFormControl('<p>this is a test</p>');
+}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.module.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor-min-height/rich-text-editor-min-height.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RichTextEditorMinHeightComponent } from './rich-text-editor-min-height.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SdsRichTextModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsRichTextModule, FormsModule, ReactiveFormsModule],
+  declarations: [RichTextEditorMinHeightComponent],
+  exports: [RichTextEditorMinHeightComponent],
+  bootstrap: [RichTextEditorMinHeightComponent],
+})
+export class RichTextEditorMinHeightModule {}

--- a/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor.stories.ts
+++ b/libs/documentation/src/lib/storybook/rich-text-editor/rich-text-editor.stories.ts
@@ -1,0 +1,76 @@
+import { CommonModule } from '@angular/common';
+import { moduleMetadata, Meta, Story } from '@storybook/angular';
+import { generateConfig, generateStackblitzLink } from 'libs/documentation/src/sandbox/sandbox-utils';
+import { RichTextEditorMinHeightModule } from './rich-text-editor-min-height/rich-text-editor-min-height.module';
+import { RichTextEditorMaxHeightModule } from './rich-text-editor-max-height/rich-text-editor-max-height.module';
+import { RichTextEditorIntroductionModule } from './rich-text-editor-introduction/rich-text-editor-introduction.module';
+
+export default {
+  title: 'Components/Rich-Text-Editor',
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CommonModule,
+        RichTextEditorMinHeightModule,
+        RichTextEditorMaxHeightModule,
+        RichTextEditorIntroductionModule,
+      ],
+    }),
+  ],
+} as Meta;
+
+export const Introduction: Story = (args) => ({
+  template: '<sds-rich-text-editor-introduction></sds-rich-text-editor-introduction>',
+  props: args,
+});
+Introduction.parameters = {
+  options: { showPanel: false },
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: { disable: true },
+};
+
+export const MinHeight: Story = (args) => ({
+  template: `<sds-rich-text-editor-min-height></sds-rich-text-editor-min-height>`,
+  props: {
+    ...args,
+  },
+});
+MinHeight.parameters = {
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: generateConfig(
+    'storybook/rich-text-editor/rich-text-editor-min-height',
+    'RichTextEditorMinHeightModule',
+    'sds-rich-text-editor-min-height'
+  ),
+  stackblitzLink: generateStackblitzLink('rich-text-editor', 'min-height'),
+};
+
+export const MaxHeight: Story = (args) => ({
+  template: `<sds-rich-text-editor-max-height></sds-rich-text-editor-max-height>`,
+  props: {
+    ...args,
+  },
+});
+MaxHeight.parameters = {
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: generateConfig(
+    'storybook/rich-text-editor/rich-text-editor-max-height',
+    'RichTextEditorMaxHeightModule',
+    'sds-rich-text-editor-max-height'
+  ),
+  stackblitzLink: generateStackblitzLink('rich-text-editor', 'max-height'),
+};
+
+export const __namedExportsOrder = ['Introduction', 'MaxHeight', 'MinHeight'];

--- a/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.component.html
+++ b/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.component.html
@@ -1,0 +1,17 @@
+<div class="desktop:grid-col-4 tablet-lg:grid-col-12 mobile-lg:grid-col-12 margin-bottom-3">
+  <sds-side-toolbar
+    [responsiveButtonText]="'Links'"
+    [responsiveDialogOptions]="responsiveDialogOptions"
+    [dialogTitleText]="'Navigation Links'"
+    [backButtonAria]="'Close Navigation Links'"
+    (responsiveDialog)="onSidenavDialogOpen($event)"
+  >
+    <ng-template #toolbarContent>
+      <sds-side-navigation
+        #sideNavigation
+        [model]="navigationModel"
+        (linkEvent)="onSideNavItemClicked($event)"
+      ></sds-side-navigation>
+    </ng-template>
+  </sds-side-toolbar>
+</div>

--- a/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.component.ts
+++ b/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.component.ts
@@ -1,0 +1,55 @@
+import { AfterViewInit, Component, TemplateRef, ViewChild } from '@angular/core';
+import { SdsSideNavigationComponent, SdsDialogConfig, SideNavigationModel, SdsDialogRef } from '@gsa-sam/components';
+import { navigationConfig } from '../side-navigation-filters/side-navigation-filters.config';
+
+@Component({
+  selector: 'sds-side-navigation-links',
+  templateUrl: './side-navigation-links.component.html',
+})
+export class SideNavigationLinksComponent implements AfterViewInit {
+  @ViewChild('sideNavigation') sideNavigation: SdsSideNavigationComponent;
+
+  responsiveDialogOptions: SdsDialogConfig = {
+    ariaLabel: 'Navigation Links',
+  };
+
+  public navigationModel: SideNavigationModel = navigationConfig;
+
+  /**
+   * Pre-select first sidenav item if sidenav is defined during initialization phase.
+   * We do AfterViewInit rather than OnInit because non-static view child references
+   * are not defined until AfterViewInit
+   * On mobile view, due to sds-side-toolbar, the sidenav does not exist until user
+   * opens the sidenav through modal. See onSidenavDialogOpen for listening for the
+   * modal to popup and pre-selecting a sidenav link
+   */
+  ngAfterViewInit() {
+    if (!this.sideNavigation) return;
+    this.sideNavigation.select(navigationConfig.navigationLinks[0].id);
+  }
+
+  onSideNavItemClicked($event) {
+    this.sideNavigation.select($event.id);
+  }
+
+  /**
+   * Execute event after user clicks to open sidenav dialog in mobile view
+   * On mobile view, sidenav will only be defined after user chooses to open the dialog.
+   *  We listen for that dialog open event,
+   * @param $event
+   */
+  onSidenavDialogOpen($event: SdsDialogRef<TemplateRef<any>>) {
+    /**
+     * We need to wait for dialog to finish opening before we can reference components
+     * inside the dialog
+     * */
+
+    $event
+      .afterOpened()
+      .toPromise()
+      .then(() => {
+        // Once the sidenav is completely initialized, select the first item
+        this.sideNavigation.select(navigationConfig.navigationLinks[0].id);
+      });
+  }
+}

--- a/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.module.ts
+++ b/libs/documentation/src/lib/storybook/side-navigation/side-navigation-links/side-navigation-links.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SideNavigationLinksComponent } from './side-navigation-links.component';
+import { SdsSideNavigationModule, SdsSideToolbarModule } from '@gsa-sam/components';
+
+@NgModule({
+  imports: [CommonModule, SdsSideNavigationModule, SdsSideToolbarModule],
+  declarations: [SideNavigationLinksComponent],
+  bootstrap: [SideNavigationLinksComponent],
+  exports: [SideNavigationLinksComponent],
+})
+export class SideNavigationLinksModule {}

--- a/libs/documentation/src/lib/storybook/side-navigation/side-navigation.stories.ts
+++ b/libs/documentation/src/lib/storybook/side-navigation/side-navigation.stories.ts
@@ -10,12 +10,19 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NavigationMode } from '@gsa-sam/components';
 import { SideNavigationIntroductionModule } from './side-navigation-introduction/side-navigation-introduction.module';
 import { SideNavigationFiltersModule } from './side-navigation-filters/side-navigation-filters.module';
+import { SideNavigationLinksModule } from './side-navigation-links/side-navigation-links.module';
 
 export default {
   title: 'Components/Side Navigation',
   decorators: [
     moduleMetadata({
-      imports: [CommonModule, NoopAnimationsModule, SideNavigationIntroductionModule, SideNavigationFiltersModule],
+      imports: [
+        CommonModule,
+        NoopAnimationsModule,
+        SideNavigationIntroductionModule,
+        SideNavigationFiltersModule,
+        SideNavigationLinksModule,
+      ],
     }),
   ],
   argTypes: {},
@@ -52,7 +59,7 @@ Filters.parameters = {
   preview: generateConfig(
     'storybook/side-navigation/side-navigation-filters',
     'SideNavigationFiltersModule',
-    'side-navigation-filters',
+    'sds-side-navigation-filters',
     [
       createCodePreviewTabData(
         'storybook/side-navigation/side-navigation-filters/side-navigation-filters.config.ts',
@@ -61,7 +68,34 @@ Filters.parameters = {
       ),
     ]
   ),
-  stackblitzLink: generateStackblitzLink('sds-side-navigation', 'filters'),
+  stackblitzLink: generateStackblitzLink('side-navigation', 'filters'),
 };
 
-export const __namedExportsOrder = ['Introduction', 'Filters'];
+export const Links: Story = (args) => ({
+  template: `<sds-side-navigation-links></sds-side-navigation-links>`,
+  props: {
+    ...args,
+  },
+});
+Links.parameters = {
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: generateConfig(
+    'storybook/side-navigation/side-navigation-links',
+    'SideNavigationLinkssModule',
+    'sds-side-navigation-links',
+    [
+      createCodePreviewTabData(
+        'storybook/side-navigation/side-navigation-filters/side-navigation-filters.config.ts',
+        'ts',
+        false
+      ),
+    ]
+  ),
+  stackblitzLink: generateStackblitzLink('side-navigation', 'links'),
+};
+
+export const __namedExportsOrder = ['Introduction', 'Filters', 'Links'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@gsa-sam/ngx-uswds-icons": "^16.0.0",
         "@gsa-sam/sam-formly": "^16.0.8",
         "@gsa-sam/sam-material-extensions": "^16.0.8",
-        "@gsa-sam/sam-styles": "^3.0.15",
+        "@gsa-sam/sam-styles": "^3.0.18",
         "@ngx-formly/core": "^6.2.1",
         "@ngx-formly/schematics": "^6.2.1",
         "@types/qs": "^6.9.5",
@@ -6277,9 +6277,9 @@
       }
     },
     "node_modules/@gsa-sam/sam-styles": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.16.tgz",
-      "integrity": "sha512-uGlsvXVmHQqHz+3hVgqvneE83/bYRtJuemGVekAicMOfB2+J/LEqDvnl6+Hmgs1ApOPp/SxvQMHECt40H2XG9Q==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.18.tgz",
+      "integrity": "sha512-NsTeVIS9H1Ba0ph03By6WRPV3jLf1WjUjLDlw8B5L23Iw1FYJ8Jo0hub+aE183sH7KDd9qS8y6sqIm0NEZwJhQ==",
       "dependencies": {
         "@uswds/uswds": "^3.3.0",
         "bootstrap-icons": "^1.10.3",
@@ -28495,7 +28495,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -28511,19 +28510,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -28538,7 +28534,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -28556,7 +28551,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@gsa-sam/ngx-uswds-icons": "^16.0.0",
     "@gsa-sam/sam-formly": "^16.0.8",
     "@gsa-sam/sam-material-extensions": "^16.0.8",
-    "@gsa-sam/sam-styles": "^3.0.15",
+    "@gsa-sam/sam-styles": "^3.0.18",
     "@ngx-formly/core": "^6.2.1",
     "@ngx-formly/schematics": "^6.2.1",
     "@types/qs": "^6.9.5",


### PR DESCRIPTION
## Description
Add demos that were missed in the transition to storybook.

This still requires an update to sam-styles before merging.

## Motivation and Context
Missed some demos when moving to storybook, adding those now.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

