### PR TITLE
Textarea maxlength

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/types/textarea.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/textarea.ts
@@ -1,11 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 
 @Component({
   selector: 'sds-formly-field-textarea',
   template: `
+    {{ props | json }}
     <div [ngClass]="{ 'usa-character-count': props.maxLength }">
       <textarea
+        #textarea
         [formControl]="formControl"
         [cols]="props.cols"
         [rows]="props.rows"
@@ -13,7 +15,6 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
         [class.usa-input--error]="showError"
         [placeholder]="props.placeholder"
         [formlyAttributes]="field"
-        [maxLength]="props.maxLength"
         (ngModelChange)="valueChange($event)"
       >
       </textarea>
@@ -28,6 +29,8 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
   `,
 })
 export class FormlyFieldTextAreaComponent extends FieldType<FieldTypeConfig> implements OnInit {
+  @ViewChild('textarea', { static: true }) textareaRef: ElementRef;
+
   defaultOptions = {
     props: {
       cols: 1,
@@ -40,6 +43,9 @@ export class FormlyFieldTextAreaComponent extends FieldType<FieldTypeConfig> imp
   ngOnInit() {
     if (!this.props.maxLength) {
       return;
+    }
+    if (this.props.maxLength) {
+      this.textareaRef.nativeElement.setAttribute('maxLength', this.props.maxLength);
     }
     const initialValue: string = this.field.formControl.value;
 

--- a/libs/packages/sam-formly/src/lib/formly/types/textarea.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/textarea.ts
@@ -4,7 +4,6 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
 @Component({
   selector: 'sds-formly-field-textarea',
   template: `
-    {{ props | json }}
     <div [ngClass]="{ 'usa-character-count': props.maxLength }">
       <textarea
         #textarea


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
This PR is to resolve the maxLenth prop for the text area, if maxLenth not set then it's defaults to 0, so need to add the maxLenth attribute dynamically

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

