### PR TITLE
1388: Update Formly Autocomplete to make sure ID in label and Autocomplete Input match

### DIFF
--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-basic/formly-autocomplete-basic.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-basic/formly-autocomplete-basic.component.ts
@@ -28,7 +28,6 @@ export class FormlyAutocompleteBasicComponent implements OnInit {
           type: 'autocomplete',
           props: {
             label: 'Auto Complete',
-            hideLabel: true,
             service: this.service,
             configuration: this.settings,
             model: this.autocompleteModel,
@@ -49,6 +48,7 @@ export class FormlyAutocompleteBasicComponent implements OnInit {
 
   setup() {
     this.settings.id = 'autocompleteBasic';
+    this.fields[0].fieldGroup[0].id = this.settings.id;
     this.settings.primaryKeyField = 'id';
     this.settings.primaryTextField = 'name';
     this.settings.secondaryTextField = 'subtext';

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-basic/formly-autocomplete-basic.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-basic/formly-autocomplete-basic.component.ts
@@ -26,8 +26,10 @@ export class FormlyAutocompleteBasicComponent implements OnInit {
         {
           key: 'firstName',
           type: 'autocomplete',
+          id: 'autocompleteBasic',
           props: {
             label: 'Auto Complete',
+            hideLabel: true,
             service: this.service,
             configuration: this.settings,
             model: this.autocompleteModel,
@@ -47,8 +49,6 @@ export class FormlyAutocompleteBasicComponent implements OnInit {
   }
 
   setup() {
-    this.settings.id = 'autocompleteBasic';
-    this.fields[0].fieldGroup[0].id = this.settings.id;
     this.settings.primaryKeyField = 'id';
     this.settings.primaryTextField = 'name';
     this.settings.secondaryTextField = 'subtext';

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-count/formly-autocomplete-count.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-count/formly-autocomplete-count.component.ts
@@ -27,6 +27,7 @@ export class FormlyAutocompleteCountComponent {
           id: 'autocompleteMinchar',
           props: {
             label: 'Auto Complete',
+            hideLabel: true,
             service: this.service,
             configuration: this.settings,
             model: this.autocompleteModel,

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-count/formly-autocomplete-count.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-count/formly-autocomplete-count.component.ts
@@ -24,9 +24,9 @@ export class FormlyAutocompleteCountComponent {
         {
           key: 'firstName',
           type: 'autocomplete',
+          id: 'autocompleteMinchar',
           props: {
             label: 'Auto Complete',
-            hideLabel: true,
             service: this.service,
             configuration: this.settings,
             model: this.autocompleteModel,
@@ -41,7 +41,6 @@ export class FormlyAutocompleteCountComponent {
   }
 
   setup() {
-    this.settings.id = 'autocompleteMinchar';
     this.settings.primaryKeyField = 'id';
     this.settings.primaryTextField = 'name';
     this.settings.secondaryTextField = 'subtext';

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.html
@@ -1,5 +1,8 @@
 <h4>Setting Formly Autocomplete ID</h4>
-<p>This demo shows the multiple ways that ID can be set on autocomplete so that the label and autocomplete input are connected for accessibility purposes.</p>
+<p>
+  This demo shows the multiple ways that ID can be set on autocomplete so that the label and autocomplete input are
+  connected for accessibility purposes.
+</p>
 <p>First Name shows how the ID can be dynamically set and still ensure the IDs match between label and input.</p>
 <p>Middle Name shows a static ID being set and used by both label and autocomplete input.</p>
 <p>Last Name shows the ID being auto-assigned by Formly and used by both label and autocomplete input.</p>

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.html
@@ -1,0 +1,13 @@
+<h4>Setting Formly Autocomplete ID</h4>
+<p>This demo shows the multiple ways that ID can be set on autocomplete so that the label and autocomplete input are connected for accessibility purposes.</p>
+<p>First Name shows how the ID can be dynamically set and still ensure the IDs match between label and input.</p>
+<p>Middle Name shows a static ID being set and used by both label and autocomplete input.</p>
+<p>Last Name shows the ID being auto-assigned by Formly and used by both label and autocomplete input.</p>
+<form [formGroup]="form">
+  <formly-form [model]="model" [fields]="fields" [options]="options" (modelChange)="onModelChange()" [form]="form">
+  </formly-form>
+</form>
+<br />
+
+<h4>Formly Model</h4>
+<pre>{{ model | json }}</pre>

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.ts
@@ -11,13 +11,12 @@ import { BehaviorSubject } from 'rxjs';
   providers: [AutocompleteSampleDataService],
 })
 export class FormlyAutocompleteIdComponent implements OnInit {
-
   results: any;
   form = new UntypedFormGroup({});
   model: any = {
     firstName: {},
     middleName: {},
-    lastName: {}
+    lastName: {},
   };
   options: FormlyFormOptions = {};
 
@@ -68,7 +67,7 @@ export class FormlyAutocompleteIdComponent implements OnInit {
             model: this.lastNameModel,
             modelChange: this.changes,
           },
-        }
+        },
       ],
     },
   ];
@@ -82,10 +81,9 @@ export class FormlyAutocompleteIdComponent implements OnInit {
   }
 
   setup() {
+    // Set first name autocomplete to connect label and input
     this.firstNameSettings.id = 'firstNameAutocomplete';
     this.fields[0].fieldGroup[0].id = this.firstNameSettings.id;
-
-
 
     this.firstNameSettings.primaryKeyField = 'id';
     this.firstNameSettings.primaryTextField = 'name';
@@ -174,5 +172,4 @@ export class FormlyAutocompleteIdComponent implements OnInit {
     const newObjModel = new SDSSelectedItemModel(newModel);
     this.form.get('filters.firstName').patchValue(newObjModel.items);
   }
-
 }

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.component.ts
@@ -1,0 +1,178 @@
+import { Component, OnInit } from '@angular/core';
+import { AutocompleteSampleDataService } from '../services/autocomplete-sample.service';
+import { UntypedFormGroup } from '@angular/forms';
+import { SDSAutocompletelConfiguration, SDSSelectedItemModel, SelectionMode } from '@gsa-sam/components';
+import { FormlyFormOptions, FormlyFieldConfig } from '@ngx-formly/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Component({
+  selector: 'sds-formly-autocomplete-id',
+  templateUrl: './formly-autocomplete-id.component.html',
+  providers: [AutocompleteSampleDataService],
+})
+export class FormlyAutocompleteIdComponent implements OnInit {
+
+  results: any;
+  form = new UntypedFormGroup({});
+  model: any = {
+    firstName: {},
+    middleName: {},
+    lastName: {}
+  };
+  options: FormlyFormOptions = {};
+
+  public firstNameSettings = new SDSAutocompletelConfiguration();
+  public middleNameSettings = new SDSAutocompletelConfiguration();
+  public lastNameSettings = new SDSAutocompletelConfiguration();
+
+  public firstNameModel = new SDSSelectedItemModel();
+  public middleNameModel = new SDSSelectedItemModel();
+  public lastNameModel = new SDSSelectedItemModel();
+
+  public filterChange$ = new BehaviorSubject<object>(null);
+  fields: FormlyFieldConfig[] = [
+    {
+      key: 'filters',
+      props: { label: 'Keyword' },
+      fieldGroup: [
+        {
+          key: 'firstName',
+          type: 'autocomplete',
+          props: {
+            label: 'First Name',
+            service: this.service,
+            configuration: this.firstNameSettings,
+            model: this.firstNameModel,
+            modelChange: this.changes,
+          },
+        },
+        {
+          key: 'middletName',
+          type: 'autocomplete',
+          id: 'middleNameAutocomplete',
+          props: {
+            label: 'Middle Name',
+            service: this.service,
+            configuration: this.middleNameSettings,
+            model: this.middleNameModel,
+            modelChange: this.changes,
+          },
+        },
+        {
+          key: 'lastName',
+          type: 'autocomplete',
+          props: {
+            label: 'Last Name',
+            service: this.service,
+            configuration: this.lastNameSettings,
+            model: this.lastNameModel,
+            modelChange: this.changes,
+          },
+        }
+      ],
+    },
+  ];
+
+  constructor(public service: AutocompleteSampleDataService) {
+    this.setup();
+  }
+
+  changes(value) {
+    console.log(value);
+  }
+
+  setup() {
+    this.firstNameSettings.id = 'firstNameAutocomplete';
+    this.fields[0].fieldGroup[0].id = this.firstNameSettings.id;
+
+
+
+    this.firstNameSettings.primaryKeyField = 'id';
+    this.firstNameSettings.primaryTextField = 'name';
+    this.firstNameSettings.secondaryTextField = 'subtext';
+    this.firstNameSettings.labelText = 'First Name';
+    this.firstNameSettings.selectionMode = SelectionMode.SINGLE;
+    this.firstNameSettings.autocompletePlaceHolderText = 'eg: Level 1';
+    this.firstNameSettings.debounceTime = 350;
+    this.firstNameSettings.hideCloseIcon = true;
+
+    this.middleNameSettings.primaryKeyField = 'id';
+    this.middleNameSettings.primaryTextField = 'name';
+    this.middleNameSettings.secondaryTextField = 'subtext';
+    this.middleNameSettings.labelText = 'Middle Name';
+    this.middleNameSettings.selectionMode = SelectionMode.SINGLE;
+    this.middleNameSettings.autocompletePlaceHolderText = 'eg: Level 1';
+    this.middleNameSettings.debounceTime = 350;
+    this.middleNameSettings.hideCloseIcon = true;
+
+    this.lastNameSettings.primaryKeyField = 'id';
+    this.lastNameSettings.primaryTextField = 'name';
+    this.lastNameSettings.secondaryTextField = 'subtext';
+    this.lastNameSettings.labelText = 'Last Name';
+    this.lastNameSettings.selectionMode = SelectionMode.SINGLE;
+    this.lastNameSettings.autocompletePlaceHolderText = 'eg: Level 1';
+    this.lastNameSettings.debounceTime = 350;
+    this.lastNameSettings.hideCloseIcon = true;
+  }
+
+  onModelChange() {
+    // To changes the close icon on modal change
+    if (this.model.filters.firstName[0].id !== '1') {
+      this.firstNameSettings.hideCloseIcon = false;
+    } else {
+      this.firstNameSettings.hideCloseIcon = true;
+    }
+  }
+
+  head(array) {
+    return array && array.length ? array[0] : undefined;
+  }
+
+  // To display the selected model values
+  public ngOnInit() {
+    this.filterChange$.subscribe((res) => (this.results = res));
+  }
+
+  // Method to programatically set the FormControl value which gets converted to the items array through the writeValue method
+  setModelVal() {
+    this.form.get('filters.firstName').patchValue([
+      {
+        id: '3',
+        parentId: '2',
+        name: 'Level 3',
+        subtext: 'id 3',
+        type: 'Level 3',
+        childCount: 2,
+        highlighted: true,
+      },
+    ]);
+  }
+
+  // Method to programatically set the FormControl value which gets converted to the items array through the writeValue method
+  setModelObj() {
+    const newModel = [
+      {
+        id: '3',
+        parentId: '2',
+        name: 'Level 3',
+        subtext: 'id 3',
+        type: 'Level 3',
+        childCount: 2,
+        highlighted: true,
+      },
+      {
+        id: '42',
+        parentId: '41',
+        name: 'Level 6',
+        subtext: 'id 42',
+        type: 'Level 6',
+        childCount: 3,
+        highlighted: true,
+      },
+    ];
+
+    const newObjModel = new SDSSelectedItemModel(newModel);
+    this.form.get('filters.firstName').patchValue(newObjModel.items);
+  }
+
+}

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormlyAutocompleteIdComponent } from './formly-autocomplete-id.component';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { SdsFormlyModule } from '@gsa-sam/sam-formly';
+import { FormlyModule } from '@ngx-formly/core';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    SdsFormlyModule,
+    FormsModule,
+    FormlyModule.forRoot()
+  ],
+  declarations: [FormlyAutocompleteIdComponent],
+  exports: [FormlyAutocompleteIdComponent],
+  bootstrap: [FormlyAutocompleteIdComponent],
+})
+export class FormlyAutocompleteIdModule { }

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.module.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete-id/formly-autocomplete-id.module.ts
@@ -6,15 +6,9 @@ import { SdsFormlyModule } from '@gsa-sam/sam-formly';
 import { FormlyModule } from '@ngx-formly/core';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    SdsFormlyModule,
-    FormsModule,
-    FormlyModule.forRoot()
-  ],
+  imports: [CommonModule, ReactiveFormsModule, SdsFormlyModule, FormsModule, FormlyModule.forRoot()],
   declarations: [FormlyAutocompleteIdComponent],
   exports: [FormlyAutocompleteIdComponent],
   bootstrap: [FormlyAutocompleteIdComponent],
 })
-export class FormlyAutocompleteIdModule { }
+export class FormlyAutocompleteIdModule {}

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete.stories.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete.stories.ts
@@ -13,6 +13,7 @@ import { FormlyAutocompleteFreetextModule } from './formly-autocomplete-free-tex
 import { FormlyAutocompleteInputModule } from './formly-autocomplete-input/formly-autocomplete-input.module';
 import { FormlyAutocompleteTagModule } from './formly-autocomplete-tag/formly-autocomplete-tag.module';
 import { FormlyAutocompleteValidationModule } from './formly-autocomplete-validation/formly-autocomplete-validation.module';
+import { FormlyAutocompleteIdModule } from './formly-autocomplete-id/formly-autocomplete-id.module';
 
 const disable = {
   table: {
@@ -44,6 +45,7 @@ export default {
         FormlyAutocompleteInputModule,
         FormlyAutocompleteTagModule,
         FormlyAutocompleteValidationModule,
+        FormlyAutocompleteIdModule
       ],
     }),
   ],
@@ -181,12 +183,31 @@ Validation.parameters = {
   stackblitzLink: generateStackblitzLink('formly-autocomplete', 'validation'),
 };
 
+export const ID: Story = (args) => ({
+  template: '<sds-formly-autocomplete-id></sds-formly-autocomplete-id>',
+  props: args,
+});
+ID.parameters = {
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: generateConfig(
+    'storybook/formly/formly-autocomplete/formly-autocomplete-id',
+    'FormlyAutocompleteIdModule',
+    'sds-formly-autocomplete-id'
+  ),
+  stackblitzLink: generateStackblitzLink('formly-autocomplete', 'id'),
+};
+
 export const __namedExportsOrder = [
   'Introduction',
   'Basic',
   'Count',
   'Disable',
   'Freetext',
+  'ID',
   'Input',
   'Tag',
   'Validation',

--- a/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete.stories.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-autocomplete/formly-autocomplete.stories.ts
@@ -45,7 +45,7 @@ export default {
         FormlyAutocompleteInputModule,
         FormlyAutocompleteTagModule,
         FormlyAutocompleteValidationModule,
-        FormlyAutocompleteIdModule
+        FormlyAutocompleteIdModule,
       ],
     }),
   ],

--- a/libs/packages/sam-formly/src/lib/formly/types/autocomplete.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/autocomplete.ts
@@ -19,6 +19,11 @@ export class FormlyFieldAutoCompleteComponent extends AbstractSdsFormly implemen
     this.cdr = _cdr;
   }
   ngAfterViewInit(): void {
+    if (this.template.configuration.id !== undefined && this.template.configuration.id !== this.id) {
+      console.warn(
+        `Formly Autocomplete ID mismatch: Formly Autocomplete ID(${this.id}) does not match Autocomplete Configuration ID (${this.template.configuration.id})`
+      );
+    }
     if (!this.template.configuration.id) {
       this.template.configuration.id = this.id;
     }

--- a/libs/packages/sam-formly/src/lib/formly/types/autocomplete.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/autocomplete.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewChild, ChangeDetectorRef, AfterViewInit } from '@angular/core';
 import { AbstractSdsFormly } from '../sds-formly';
 import { SDSAutocompleteComponent } from '@gsa-sam/components';
 
@@ -7,7 +7,7 @@ import { SDSAutocompleteComponent } from '@gsa-sam/components';
   template: ` <sds-autocomplete [formControl]="formControl"></sds-autocomplete> `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FormlyFieldAutoCompleteComponent extends AbstractSdsFormly {
+export class FormlyFieldAutoCompleteComponent extends AbstractSdsFormly implements AfterViewInit {
   @ViewChild(SDSAutocompleteComponent, { static: true }) public template: SDSAutocompleteComponent;
   defaultOptions = {
     props: {
@@ -17,5 +17,10 @@ export class FormlyFieldAutoCompleteComponent extends AbstractSdsFormly {
   constructor(_cdr: ChangeDetectorRef) {
     super(); /* istanbul ignore next */
     this.cdr = _cdr;
+  }
+  ngAfterViewInit(): void {
+    if (!this.template.configuration.id) {
+      this.template.configuration.id = this.id;
+    }
   }
 }


### PR DESCRIPTION
## Description
Setting the id field in the autocomplete fieldGroup would not cause the label and input to be connected like other inputs were. This caused an accessibility issue where clicking on the label would not result in the in autocomplete input becoming focused.

This PR:
- Adds logic so that if the SDS autocomplete does not have an ID assigned to it, it will be assigned the ID that Formly is using. This will ensure that if no ID is configured, clicking the label will focus on the auto complete.
- Adds a warning that will display if there is a mismatch between the Formly tracked ID (used in label's for field) and the Autocomplete Input ID
- Adds a demo showing how to set the ID so that the label and autocomplete input are connected. 



The new demo has three autocompletes showing the different ways to set the ID so that the label and input are connected. The first autocomplete is set up how previous demo, and presumebly MFEs, had been setting IDs. This method requires that the formly fieldGroup ID be set. The second shows setting the formly fieldGroup ID. And the third show not setting any id, which will revert to using the formly assigned ID

## Motivation and Context
Addresses #1388 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

