### PR TITLE
Update logic on Autocomplete focusRemoved function

### DIFF
--- a/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
+++ b/libs/packages/components/src/lib/autocomplete-search/autocomplete-search.component.ts
@@ -195,7 +195,7 @@ export class SDSAutocompleteSearchComponent implements ControlValueAccessor {
   }
 
   /**
-   *
+   * Triggered when user clicks or enters on the up carat OR clicks outside this component
    * @param event
    */
   checkForFocus(event): void {
@@ -213,20 +213,28 @@ export class SDSAutocompleteSearchComponent implements ControlValueAccessor {
    *
    */
   private focusRemoved() {
-    if (this.configuration) {
-      if (this.configuration.selectionMode === SelectionMode.SINGLE) {
-        if (this.configuration.isFreeTextEnabled) {
-          if (this.model.items.length > 0) {
-            SDSSelectedItemModelHelper.clearItems(this.model.items);
-            this.propogateChange(this.model);
-          }
-          const val = this.createFreeTextItem();
-          this.selectItem(val);
-        } else if (this.model.items.length > 0) {
-          this.inputValue = this.getObjectValue(this.model.items[0], this.configuration.primaryTextField);
-        } else {
-          this.inputValue = '';
+    if (this.configuration?.selectionMode === SelectionMode.SINGLE) {
+      if (this.configuration.isFreeTextEnabled) {
+        // Only one option allowed and that one option has been made so delete to user input.
+        if (this.model.items.length > 0 && this.model.items[0]['name'] !== this.inputValue) {
+          SDSSelectedItemModelHelper.clearItems(this.model.items);
+          this.propogateChange(this.model);
         }
+        if(this.inputValue === ''){
+
+        } else if(this.model.items.length === 0 && this.inputValue !== ''){
+          const customItem = this.createFreeTextItem();
+          this.selectItem(customItem);
+        }else if (
+          this.model.items.length > 0 &&
+          this.model.items[0]['name'] !== this.inputValue
+        ){
+          const customItem = this.createFreeTextItem();
+          this.selectItem(customItem);
+        }
+
+      } else if (this.model.items.length > 0) {
+        this.inputValue = this.getObjectValue(this.model.items[0], this.configuration.primaryTextField);
       } else {
         this.inputValue = '';
       }


### PR DESCRIPTION
## Description
Update logic on focusRemoved function so that item is selected and focus pushed back to autocomplete only when input is not blank and has changed.

## Motivation and Context
Resolves #1420 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

