### PR TITLE
Text prefix removed for formly input

### DIFF
--- a/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-affix/formly-input-affix.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-input/formly-input-affix/formly-input-affix.component.ts
@@ -12,14 +12,6 @@ export class FormlyInputAffixComponent {
   options: FormlyFormOptions = {};
   fields: FormlyFieldConfig[] = [
     {
-      key: 'prefix',
-      type: 'input',
-      props: {
-        label: 'Entity Name with prefix',
-        prefix: '$',
-      },
-    },
-    {
       key: 'suffix',
       type: 'input',
       props: {

--- a/libs/packages/sam-formly/src/lib/formly/types/input.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/input.ts
@@ -6,7 +6,6 @@ import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
   template: `
     <div class="usa-input-group maxw-mobile-lg">
       <div *ngIf="props.prefix || props.prefixIcon" class="usa-input-prefix" aria-hidden="true">
-        <span *ngIf="props.prefix && !props.prefixIcon" (click)="onPrefixClick($event)">{{ props.prefix }}</span>
         <span *ngIf="props.prefixIcon && !props.prefix" (click)="onPrefixClick($event)">
           <usa-icon [icon]="props.prefixIcon" size="lg" class="font-sans-xs"></usa-icon>
         </span>


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
https://github.com/GSA/sam-design-system/issues/1392

This PR is to not allowing the user to add prefix text.

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

