### PR TITLE
Allow icon to be removed without destroying directive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
 jobs:
   build:
     working_directory: ~/project/sam-design-system

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -33,7 +33,12 @@ export class ExternalLinkDirective implements OnChanges {
 
   private readonly emailLinkKeyword = 'mailto';
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string, private el: ElementRef, private vc: ViewContainerRef, private renderer: Renderer2) {}
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: string,
+    private el: ElementRef,
+    private vc: ViewContainerRef,
+    private renderer: Renderer2
+  ) {}
 
   public ngOnChanges() {
     this.hrefAttr = this.href;
@@ -49,10 +54,9 @@ export class ExternalLinkDirective implements OnChanges {
     const ariaLabel = this._getAriaLabel();
     (this.el.nativeElement as HTMLAnchorElement).setAttribute('aria-label', ariaLabel);
 
-
     if (!this.hideIcon && !this.iconVisible) {
       this.createIcon();
-    } else if(this.hideIcon && this.iconVisible){
+    } else if (this.hideIcon && this.iconVisible) {
       this.removeIcon();
     }
   }
@@ -103,15 +107,15 @@ export class ExternalLinkDirective implements OnChanges {
       !this.internalLinks.includes(link)
     );
   }
-  private get iconVisible(): boolean{
+  private get iconVisible(): boolean {
     return this.el.nativeElement.classList.contains('usa-link--external');
   }
-  private createIcon(): void{
+  private createIcon(): void {
     this.el.nativeElement.classList.add('usa-link--external');
     this.el.nativeElement.classList.add('display-inline-block');
   }
-  private removeIcon(): void{
-    this.renderer.removeClass(this.el.nativeElement, 'usa-link--external')
-    this.renderer.removeClass(this.el.nativeElement, 'display-inline-block')
+  private removeIcon(): void {
+    this.renderer.removeClass(this.el.nativeElement, 'usa-link--external');
+    this.renderer.removeClass(this.el.nativeElement, 'display-inline-block');
   }
 }

--- a/libs/packages/components/src/lib/external-link/external-link.directive.ts
+++ b/libs/packages/components/src/lib/external-link/external-link.directive.ts
@@ -8,6 +8,7 @@ import {
   ViewContainerRef,
   OnChanges,
   AfterViewInit,
+  Renderer2,
 } from '@angular/core';
 
 import { isPlatformBrowser } from '@angular/common';
@@ -32,7 +33,7 @@ export class ExternalLinkDirective implements OnChanges {
 
   private readonly emailLinkKeyword = 'mailto';
 
-  constructor(@Inject(PLATFORM_ID) private platformId: string, private el: ElementRef, private vc: ViewContainerRef) {}
+  constructor(@Inject(PLATFORM_ID) private platformId: string, private el: ElementRef, private vc: ViewContainerRef, private renderer: Renderer2) {}
 
   public ngOnChanges() {
     this.hrefAttr = this.href;
@@ -48,8 +49,11 @@ export class ExternalLinkDirective implements OnChanges {
     const ariaLabel = this._getAriaLabel();
     (this.el.nativeElement as HTMLAnchorElement).setAttribute('aria-label', ariaLabel);
 
-    if (!this.hideIcon) {
+
+    if (!this.hideIcon && !this.iconVisible) {
       this.createIcon();
+    } else if(this.hideIcon && this.iconVisible){
+      this.removeIcon();
     }
   }
 
@@ -82,7 +86,7 @@ export class ExternalLinkDirective implements OnChanges {
       return currentAriaLabel;
     }
 
-    /** Aria label is attached, but does not indicate link will open in new window. 
+    /** Aria label is attached, but does not indicate link will open in new window.
        Add opens in new window keyword to aria label */
     return `${currentAriaLabel} - opens in a new window`;
   }
@@ -99,9 +103,15 @@ export class ExternalLinkDirective implements OnChanges {
       !this.internalLinks.includes(link)
     );
   }
-  private createIcon() {
-    // tslint:disable-next-line:no-unused-expression
+  private get iconVisible(): boolean{
+    return this.el.nativeElement.classList.contains('usa-link--external');
+  }
+  private createIcon(): void{
     this.el.nativeElement.classList.add('usa-link--external');
     this.el.nativeElement.classList.add('display-inline-block');
+  }
+  private removeIcon(): void{
+    this.renderer.removeClass(this.el.nativeElement, 'usa-link--external')
+    this.renderer.removeClass(this.el.nativeElement, 'display-inline-block')
   }
 }


### PR DESCRIPTION
## Description
Update ExternalLinkDirective to allow icon to be toggled with inputs. Previously the element would have needed to be deleted and re-created to achieve this behavior. This can be tested in the external link configurable demo.

Also fixes circleCI issue preventing circleCi tests from running.

## Motivation and Context
Addressed #1425 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

