### PR TITLE
Add property for additional message when required validator applied to type=datepicker

### DIFF
--- a/libs/documentation/src/lib/storybook/formly/formly-datepicker/formly-datepicker-basic/formly-datepicker-basic.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-datepicker/formly-datepicker-basic/formly-datepicker-basic.component.ts
@@ -16,8 +16,8 @@ export class FormlyDatepickerBasicComponent {
       key: 'expirationDateOpen',
       type: 'datepicker',
       props: {
-        customDateMessage: true,
         required: true,
+        invalidDateMessage: true,
         label: 'Expiration Date (no validation)',
         placeholder:
           'eg: ' +

--- a/libs/documentation/src/lib/storybook/formly/formly-datepicker/formly-datepicker-basic/formly-datepicker-basic.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-datepicker/formly-datepicker-basic/formly-datepicker-basic.component.ts
@@ -16,6 +16,8 @@ export class FormlyDatepickerBasicComponent {
       key: 'expirationDateOpen',
       type: 'datepicker',
       props: {
+        customDateMessage: true,
+        required: true,
         label: 'Expiration Date (no validation)',
         placeholder:
           'eg: ' +

--- a/libs/packages/sam-formly/src/lib/formly/formly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.module.ts
@@ -82,6 +82,14 @@ export function invalidDateFormatValidationMessage(err, field: FormlyFieldConfig
   return `Valid date format required (ex: MM/DD/YYYY)`;
 }
 
+export function requireOrInvalidDateFormat(err, field: FormlyFieldConfig) {
+  if(field.type === 'datepicker' && field.props['customDateMessage'] && field.formControl?.getError('matDatepickerParse')){
+    return `Valid date format required (ex: MM/DD/YYYY)`;
+  } else {
+    return 'This field is required';
+  }
+}
+
 export function matDatepickerMinValidationMessage(err, field: FormlyFieldConfig) {
   const fieldWithMinDate = field.props.minDate ? field : field.parent;
   if (!fieldWithMinDate) {
@@ -187,7 +195,7 @@ export const DATE_FORMAT: MatDateFormats = {
       },
 
       validationMessages: [
-        { name: 'required', message: 'This field is required' },
+        { name: 'required', message: requireOrInvalidDateFormat },
         { name: 'minLength', message: minLengthValidationMessage },
         { name: 'maxLength', message: maxLengthValidationMessage },
         { name: 'min', message: minValidationMessage },

--- a/libs/packages/sam-formly/src/lib/formly/formly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.module.ts
@@ -85,7 +85,7 @@ export function invalidDateFormatValidationMessage(err, field: FormlyFieldConfig
 export function requireOrInvalidDateFormat(err, field: FormlyFieldConfig) {
   if (
     field.type === 'datepicker' &&
-    field.props['customDateMessage'] &&
+    field.props['invalidDateMessage'] &&
     field.formControl?.getError('matDatepickerParse')
   ) {
     return `Valid date format required (ex: MM/DD/YYYY)`;

--- a/libs/packages/sam-formly/src/lib/formly/formly.module.ts
+++ b/libs/packages/sam-formly/src/lib/formly/formly.module.ts
@@ -83,7 +83,11 @@ export function invalidDateFormatValidationMessage(err, field: FormlyFieldConfig
 }
 
 export function requireOrInvalidDateFormat(err, field: FormlyFieldConfig) {
-  if(field.type === 'datepicker' && field.props['customDateMessage'] && field.formControl?.getError('matDatepickerParse')){
+  if (
+    field.type === 'datepicker' &&
+    field.props['customDateMessage'] &&
+    field.formControl?.getError('matDatepickerParse')
+  ) {
     return `Valid date format required (ex: MM/DD/YYYY)`;
   } else {
     return 'This field is required';


### PR DESCRIPTION
## Description
Add field to change the message displayed when datepicker has the required validator applied. If this custom field is set true AND there is something typed into the field THEN a message about an invalid format will show rather than the field is required error message.

## Motivation and Context
Addresses #1427 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

