### PR TITLE
Add popper peer dep to packages

### DIFF
--- a/libs/packages/components/package.json
+++ b/libs/packages/components/package.json
@@ -14,6 +14,7 @@
     "@angular/common": ">=17.0.0 <18.0.0",
     "@angular/core": ">=17.0.0 <18.0.0",
     "accessible-html5-video-player": "^1.0.6",
-    "ngx-bootstrap-icons": "^1.7.2"
+    "ngx-bootstrap-icons": "^1.7.2",
+    "@popperjs/core": "^2.11.8"
   }
 }

--- a/libs/packages/sam-formly/package.json
+++ b/libs/packages/sam-formly/package.json
@@ -16,6 +16,7 @@
     "@ngx-formly/core": ">=6.2.0",
     "@gsa-sam/components": ">=17.0.0",
     "@gsa-sam/sam-material-extensions": ">=17.0.0",
-    "@gsa-sam/ngx-uswds": ">=17.0.0"
+    "@gsa-sam/ngx-uswds": ">=17.0.0",
+    "@popperjs/core": "^2.11.8"
   }
 }


### PR DESCRIPTION
## Description
Adding popper.js peer dep to sds-components and sds-formly packages. Not including in material-extensions as neither popover nor tooltip are used in that package.

## Motivation and Context
Peer dep needed to ensure that teams have popper.js installed to avoid errors

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

