### PR TITLE
Add Condition To Prevent Horizontal Filter Without Label

### DIFF
--- a/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-horizontal/formly-filter-horizontal.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-horizontal/formly-filter-horizontal.component.ts
@@ -17,7 +17,6 @@ export class FormlyFilterHorizontalComponent {
       type: 'multicheckbox',
       props: {
         label: 'Status',
-        group: 'popover',
         options: [
           {
             value: 'active',
@@ -39,7 +38,6 @@ export class FormlyFilterHorizontalComponent {
       type: 'multicheckbox',
       props: {
         label: 'Socio-Economic Status',
-        group: 'popover',
         options: [
           {
             value: 'vet',
@@ -60,7 +58,6 @@ export class FormlyFilterHorizontalComponent {
       key: 'dateRange',
       props: {
         label: 'Date Range',
-        group: 'popover',
         autoClose: 'false',
       },
       fieldGroup: [
@@ -128,7 +125,6 @@ export class FormlyFilterHorizontalComponent {
       type: 'daterangepickerv2',
       hide: true,
       props: {
-        group: 'popover',
         label: 'Expiration Date Range',
         minDate: new Date(2019, 9, 5),
         maxDate: new Date(2020, 11, 15),
@@ -147,7 +143,6 @@ export class FormlyFilterHorizontalComponent {
       type: 'input',
       hide: true,
       props: {
-        group: 'popover',
         label: 'Entity Name',
         placeholder: 'eg: Acme Corporation',
         description: 'Enter the name of your entity.',

--- a/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.html
@@ -7,35 +7,42 @@
 <p>Below are a couple of possible changes to check after updating to 17.0.9</p>
 <h3>Field Labels Required</h3>
 <p>
-  Going forward each element of the fields array that is passed into formly must have a label to be displayed. This label will be used to label the dropdown in the horizontal filters toolbar. If a label is not provided, the field will not be shown within horizontal filters.
+  Going forward each element of the fields array that is passed into formly must have a label to be displayed. This
+  label will be used to label the dropdown in the horizontal filters toolbar. If a label is not provided, the field will
+  not be shown within horizontal filters.
 </p>
-<p>Below is a barebones example of the expected structure for a horizontal filter. Note that label <i>Status</i> is provided within the props field of this FormlyFieldConfig</p>
+<p>
+  Below is a barebones example of the expected structure for a horizontal filter. Note that label <i>Status</i> is
+  provided within the props field of this FormlyFieldConfig
+</p>
 <code>
   fields: FormlyFieldConfig&#91;&#93; = &#91;<br />
-    &emsp;&#123;<br />
-    &emsp;&emsp;key: 'status',<br />
-    &emsp;&emsp;type: 'multicheckbox',<br />
-    &emsp;&emsp;props: &#123;<br />
-    &emsp;&emsp;&emsp;label: 'Status',<br />
-    &emsp;&emsp;&emsp;options: &#91;<br />
-    &emsp;&emsp;&emsp;&emsp;&#123;<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'active',<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Active',<br />
-    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
-    &emsp;&emsp;&emsp;&emsp;&#123;<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'inactive',<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Inactive',<br />
-    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
-    &emsp;&emsp;&emsp;&emsp;&#123;<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'all',<br />
-    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'All',<br />
-    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
-    &emsp;&emsp;&emsp;&#93;,<br />
-    &emsp;&emsp;&#125;,<br />
-    &emsp;&#125;<br />
-    &#93;
+  &emsp;&#123;<br />
+  &emsp;&emsp;key: 'status',<br />
+  &emsp;&emsp;type: 'multicheckbox',<br />
+  &emsp;&emsp;props: &#123;<br />
+  &emsp;&emsp;&emsp;label: 'Status',<br />
+  &emsp;&emsp;&emsp;options: &#91;<br />
+  &emsp;&emsp;&emsp;&emsp;&#123;<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;value: 'active',<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Active',<br />
+  &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+  &emsp;&emsp;&emsp;&emsp;&#123;<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;value: 'inactive',<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Inactive',<br />
+  &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+  &emsp;&emsp;&emsp;&emsp;&#123;<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;value: 'all',<br />
+  &emsp;&emsp;&emsp;&emsp;&emsp;label: 'All',<br />
+  &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+  &emsp;&emsp;&emsp;&#93;,<br />
+  &emsp;&emsp;&#125;,<br />
+  &emsp;&#125;<br />
+  &#93;
 </code>
 <h3>OnInit Hook</h3>
 <p>
-  Previously the onInit hook could be attached to a field and would trigger as the horizontal filters component loaded in. This is not the case anymore. The onInit hook will now trigger when the popover containing the field is opened, rather than on page load. If some action needs to be taken on page load, please use an Angular lifecycle hook.
+  Previously the onInit hook could be attached to a field and would trigger as the horizontal filters component loaded
+  in. This is not the case anymore. The onInit hook will now trigger when the popover containing the field is opened,
+  rather than on page load. If some action needs to be taken on page load, please use an Angular lifecycle hook.
 </p>

--- a/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.html
@@ -2,3 +2,40 @@
   Formly filter provides an filter for text to formly forms. This filter supports a number of features to inform users
   what sort of filter is expected.
 </p>
+
+<h2>Horizontal Filters 17.0.9</h2>
+<p>Below are a couple of possible changes to check after updating to 17.0.9</p>
+<h3>Field Labels Required</h3>
+<p>
+  Going forward each element of the fields array that is passed into formly must have a label to be displayed. This label will be used to label the dropdown in the horizontal filters toolbar. If a label is not provided, the field will not be shown within horizontal filters.
+</p>
+<p>Below is a barebones example of the expected structure for a horizontal filter. Note that label <i>Status</i> is provided within the props field of this FormlyFieldConfig</p>
+<code>
+  fields: FormlyFieldConfig&#91;&#93; = &#91;<br />
+    &emsp;&#123;<br />
+    &emsp;&emsp;key: 'status',<br />
+    &emsp;&emsp;type: 'multicheckbox',<br />
+    &emsp;&emsp;props: &#123;<br />
+    &emsp;&emsp;&emsp;label: 'Status',<br />
+    &emsp;&emsp;&emsp;options: &#91;<br />
+    &emsp;&emsp;&emsp;&emsp;&#123;<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'active',<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Active',<br />
+    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+    &emsp;&emsp;&emsp;&emsp;&#123;<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'inactive',<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'Inactive',<br />
+    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+    &emsp;&emsp;&emsp;&emsp;&#123;<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;value: 'all',<br />
+    &emsp;&emsp;&emsp;&emsp;&emsp;label: 'All',<br />
+    &emsp;&emsp;&emsp;&emsp;&#125;,<br />
+    &emsp;&emsp;&emsp;&#93;,<br />
+    &emsp;&emsp;&#125;,<br />
+    &emsp;&#125;<br />
+    &#93;
+</code>
+<h3>OnInit Hook</h3>
+<p>
+  Previously the onInit hook could be attached to a field and would trigger as the horizontal filters component loaded in. This is not the case anymore. The onInit hook will now trigger when the popover containing the field is opened, rather than on page load. If some action needs to be taken on page load, please use an Angular lifecycle hook.
+</p>

--- a/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.ts
+++ b/libs/documentation/src/lib/storybook/formly/formly-filter/formly-filter-introduction/formly-filter-introduction.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'sds-formly-filter-introduction',
   templateUrl: './formly-filter-introduction.component.html',
+  preserveWhitespaces: true,
 })
 export class FormlyFilterIntroductionComponent {
   constructor() {}

--- a/libs/packages/components/package.json
+++ b/libs/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/components",
-  "version": "17.0.8",
+  "version": "17.0.9",
   "types": "../../../dist/out-tsc/libs/components/index.d.ts",
   "repository": {
     "type": "git",

--- a/libs/packages/sam-formly/package.json
+++ b/libs/packages/sam-formly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/sam-formly",
-  "version": "17.0.8",
+  "version": "17.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/GSA/sam-design-system.git"

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -33,7 +33,7 @@
   <div class="horizontal-filters grid-row">
     <div *ngFor="let field of fields">
       <div
-        *ngIf="!field.hide"
+        *ngIf="!field.hide && field.props?.label"
         [sdsPopover]="content"
         [position]="'bottom'"
         [autoClose]="'outside'"
@@ -54,6 +54,15 @@
             ></formly-form>
           </p>
         </ng-template>
+      </div>
+      <div *ngIf="!field.props?.label && field.hooks">
+        <formly-form
+              [options]="options"
+              [form]="form"
+              [model]="model"
+              [fields]="[field]"
+              (modelChange)="onModelChange($event)"
+            ></formly-form>
       </div>
     </div>
 

--- a/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
+++ b/libs/packages/sam-formly/src/lib/formly-filters/sds-filters.component.html
@@ -57,12 +57,12 @@
       </div>
       <div *ngIf="!field.props?.label && field.hooks">
         <formly-form
-              [options]="options"
-              [form]="form"
-              [model]="model"
-              [fields]="[field]"
-              (modelChange)="onModelChange($event)"
-            ></formly-form>
+          [options]="options"
+          [form]="form"
+          [model]="model"
+          [fields]="[field]"
+          (modelChange)="onModelChange($event)"
+        ></formly-form>
       </div>
     </div>
 

--- a/libs/packages/sam-material-extensions/package.json
+++ b/libs/packages/sam-material-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsa-sam/sam-material-extensions",
-  "version": "17.0.8",
+  "version": "17.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/GSA/sam-design-system.git"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sam-design-system",
-  "version": "17.0.8",
+  "version": "17.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sam-design-system",
-  "version": "17.0.8",
+  "version": "17.0.9",
   "license": "MIT",
   "scripts": {
     "start": "ng serve --configuration development",


### PR DESCRIPTION
## Description
Update condition to not render field if label is not present.
Add documentation to explain changes to horizontal filter configs caused by 17.0.7-.9

## Motivation and Context
With the latest popover changes FormlyFieldConfig parsing has changed requiring that each top-level FormlyFieldConfig contain a label to display on the toolbar. This change continues to enforces that without causing breaking console errors.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="655" alt="image" src="https://github.com/user-attachments/assets/3bba564b-43a6-4b21-a109-8619925d117d">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

