### PR TITLE
Marked as dirty after clearing the input value

### DIFF
--- a/libs/packages/sam-formly/src/lib/formly/types/input.ts
+++ b/libs/packages/sam-formly/src/lib/formly/types/input.ts
@@ -49,6 +49,7 @@ export class FormlyFieldInputComponent extends FieldType<FieldTypeConfig> {
   onClear() {
     this.field.formControl.setValue('');
     this.field.focus = true;
+    this.field.formControl.markAsDirty();
   }
 
   onSuffixClick(ev) {


### PR DESCRIPTION
<!--- Provide a brief but meaningful summary of your changes in the Title -->
<!-- The title will be used to automatically generate release notes through gren -->
<!-- 1. Include the JIRA ticket number in the title (e.g. IAE-500) -->
<!-- 2. Start the title with a verb (e.g. Change header styles) -->
<!-- 3. Use the imperative mood in the title (e.g. Fix, not Fixed or Fixes header styles) -->
<!-- 4. Use labels wisely and assign one label per issue. gren has the option to ignore issues that have one of the specified labels. -->

## Description
<!--- Describe your changes in detail -->

Making input field as dirty when clear text using the 'x' button

## Motivation and Context
<!-- If there is no existing JIRA ticket or Github issue, please provide why this change is required and what problem it solves -->
<!--- Otherwise, link to the ticket or issue here. -->

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

