### PR TITLE
1536 entity registration modules mvp stepper always enable review page even if there are formly errors

### DIFF
--- a/libs/documentation/src/lib/storybook/formly/formly-stepper/formly-stepper-advanced/custom-stepper.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-stepper/formly-stepper-advanced/custom-stepper.component.html
@@ -95,7 +95,7 @@
       [sdsStepperNav]="step"
       (click)="onSideNavClick()"
       class="display-flex justify-content-space-between"
-      [ngClass]="{ 'usa-sidenav__item--disabled': step.disabled || (step.isReview && _isReviewAndSubmitDisabled) }"
+      [ngClass]="{ 'usa-sidenav__item--disabled': step.disabled || (step.isReview  && (!canReviewWithErrors && _isReviewAndSubmitDisabled)) }"
     >
       <span>
         {{ step.text }}

--- a/libs/documentation/src/lib/storybook/formly/formly-stepper/formly-stepper-advanced/custom-stepper.component.html
+++ b/libs/documentation/src/lib/storybook/formly/formly-stepper/formly-stepper-advanced/custom-stepper.component.html
@@ -95,7 +95,10 @@
       [sdsStepperNav]="step"
       (click)="onSideNavClick()"
       class="display-flex justify-content-space-between"
-      [ngClass]="{ 'usa-sidenav__item--disabled': step.disabled || (step.isReview  && (!canReviewWithErrors && _isReviewAndSubmitDisabled)) }"
+      [ngClass]="{
+        'usa-sidenav__item--disabled':
+          step.disabled || (step.isReview && !canReviewWithErrors && _isReviewAndSubmitDisabled)
+      }"
     >
       <span>
         {{ step.text }}

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
@@ -46,7 +46,10 @@ export class SdsStepperNextDirective {
     }
 
     /** Otherwise, if next step is disabled or next step is review step and review step is disabled, disable next step */
-    if (flatSteps[nextIndex].disabled || (flatSteps[nextIndex].isReview && (!this._stepper.canReviewWithErrors && this._stepper._isReviewAndSubmitDisabled))) {
+    if (
+      flatSteps[nextIndex].disabled ||
+      (flatSteps[nextIndex].isReview && !this._stepper.canReviewWithErrors && this._stepper._isReviewAndSubmitDisabled)
+    ) {
       return true;
     }
 

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-step-buttons.ts
@@ -46,7 +46,7 @@ export class SdsStepperNextDirective {
     }
 
     /** Otherwise, if next step is disabled or next step is review step and review step is disabled, disable next step */
-    if (flatSteps[nextIndex].disabled || (flatSteps[nextIndex].isReview && this._stepper._isReviewAndSubmitDisabled)) {
+    if (flatSteps[nextIndex].disabled || (flatSteps[nextIndex].isReview && (!this._stepper.canReviewWithErrors && this._stepper._isReviewAndSubmitDisabled))) {
       return true;
     }
 

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
@@ -436,7 +436,10 @@ export class SdsStepper {
      * On non-linear mode, do not allow step change if step we are moving to is disabled or is review step.
      * In linear mode, we will run validations first, then decide whether or not to move to next step
      */
-    if (!this.linear && (step.disabled || (step.isReview && (!this.canReviewWithErrors && this._isReviewAndSubmitDisabled)))) {
+    if (
+      !this.linear &&
+      (step.disabled || (step.isReview && !this.canReviewWithErrors && this._isReviewAndSubmitDisabled))
+    ) {
       return;
     }
 

--- a/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
+++ b/libs/packages/sam-formly/src/lib/formly-stepper/sds-stepper.ts
@@ -226,6 +226,12 @@ export class SdsStepper {
   @Input() validateStepsOnInit = true;
 
   /**
+   * Input to override the check for _isReviewAndSubmitDisabled truthyness
+   */
+  @Input()
+  canReviewWithErrors = false;
+
+  /**
    * Output event - emitted when save button is clicked
    */
   @Output() saveData = new EventEmitter<{ model: any; metadata: any }>();
@@ -430,7 +436,7 @@ export class SdsStepper {
      * On non-linear mode, do not allow step change if step we are moving to is disabled or is review step.
      * In linear mode, we will run validations first, then decide whether or not to move to next step
      */
-    if (!this.linear && (step.disabled || (step.isReview && this._isReviewAndSubmitDisabled))) {
+    if (!this.linear && (step.disabled || (step.isReview && (!this.canReviewWithErrors && this._isReviewAndSubmitDisabled)))) {
       return;
     }
 


### PR DESCRIPTION
## Description
Add input `canReviewWithErrors` which allows the user to navigate to Review step even if there are unresolved errors.

## Motivation and Context
Resolves #1536 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):

## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

