### PR TITLE
Add input to button-group to support modular dashboard

### DIFF
--- a/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.component.html
+++ b/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.component.html
@@ -1,0 +1,11 @@
+<sds-button-group [mode]="'radio'" [modularDashboard]="true" (change)="handleChange($event)">
+  <sds-button-group-option value="grid-view" [aria-label]="'Grid View'">
+    <usa-icon [icon]="'grid-fill'"></usa-icon>
+  </sds-button-group-option>
+  <sds-button-group-option value="list-view" [aria-label]="'List View'" [checked]="true">
+    <usa-icon [icon]="'list'"></usa-icon>
+  </sds-button-group-option>
+  <sds-button-group-option value="list-view-2" [aria-label]="'List View 2'" [disabled]="true">
+    <usa-icon [icon]="'list'"></usa-icon>
+  </sds-button-group-option>
+</sds-button-group>

--- a/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.component.ts
+++ b/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+import { MatButtonToggleChange } from '@angular/material/button-toggle';
+
+@Component({
+  selector: 'sds-button-group-modular',
+  templateUrl: './button-group-modular.component.html',
+})
+export class ButtonGroupModularComponent {
+  constructor() {}
+
+  handleChange(event: MatButtonToggleChange) {
+    console.log(event);
+  }
+}

--- a/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.module.ts
+++ b/libs/documentation/src/lib/storybook/button-group/button-group-modular/button-group-modular.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SdsButtonGroupModule } from '@gsa-sam/sam-material-extensions';
+import { IconModule } from '@gsa-sam/ngx-uswds-icons';
+import { NgxBootstrapIconsModule, gridFill, list } from 'ngx-bootstrap-icons';
+import { ButtonGroupModularComponent } from './button-group-modular.component';
+
+@NgModule({
+  imports: [CommonModule, SdsButtonGroupModule, IconModule, NgxBootstrapIconsModule.pick({ gridFill, list })],
+  declarations: [ButtonGroupModularComponent],
+  exports: [ButtonGroupModularComponent],
+  bootstrap: [ButtonGroupModularComponent],
+})
+export class ButtonGroupModularModule {}

--- a/libs/documentation/src/lib/storybook/button-group/button-group.stories.ts
+++ b/libs/documentation/src/lib/storybook/button-group/button-group.stories.ts
@@ -10,6 +10,7 @@ import { generateConfig, generateStackblitzLink } from 'libs/documentation/src/s
 import { ButtonGroupCheckedModule } from './button-group-checked/button-group-checked.module';
 import { ButtonGroupIntroductionModule } from './button-group-introduction/button-group-introduction.module';
 import { ButtonGroupModesModule } from './button-group-modes/button-group-modes.module';
+import { ButtonGroupModularModule } from './button-group-modular/button-group-modular.module';
 
 const disable = {
   table: {
@@ -32,6 +33,7 @@ export default {
         ButtonGroupModesModule,
         ButtonGroupCheckedModule,
         ButtonGroupIntroductionModule,
+        ButtonGroupModularModule,
       ],
     }),
   ],
@@ -99,10 +101,30 @@ Checked.parameters = {
   actions: { disable: true },
   preview: generateConfig(
     'storybook/button-group/button-group-checked',
-    'ButtonGroupBasicModule',
+    'ButtonGroupCheckedModule',
     'sds-button-group-checked'
   ),
   stackblitzLink: generateStackblitzLink('button-group', 'checked'),
+};
+
+export const Modular: StoryObj = (args) => ({
+  template: `<sds-button-group-modular></sds-button-group-modular>`,
+  props: {
+    ...args,
+  },
+});
+Modular.parameters = {
+  controls: {
+    disable: true,
+    hideNoControlsWarning: true,
+  },
+  actions: { disable: true },
+  preview: generateConfig(
+    'storybook/button-group/button-group-modular',
+    'ButtonGroupModularModule',
+    'sds-button-group-modular'
+  ),
+  stackblitzLink: generateStackblitzLink('button-group', 'modular'),
 };
 
 export const Introduction: StoryObj = (args) => ({

--- a/libs/packages/sam-material-extensions/src/lib/button-group/button-group.component.html
+++ b/libs/packages/sam-material-extensions/src/lib/button-group/button-group.component.html
@@ -7,8 +7,15 @@
       class="sds-button-group__item"
       [disableRipple]="true"
       [checked]="option.checked"
+      [disabled]="option.disabled"
     >
-      <div class="usa-button" [ngClass]="{ 'usa-button--outline': !singleToggle.checked }">
+      <div
+        [ngClass]="{
+          'usa-button--outline': !modularDashboard && !singleToggle.checked,
+          'usa-button': !modularDashboard,
+          modular: modularDashboard
+        }"
+      >
         <ng-container *ngTemplateOutlet="option.buttonGroupTemplate"></ng-container>
       </div>
     </mat-button-toggle>

--- a/libs/packages/sam-material-extensions/src/lib/button-group/button-group.component.ts
+++ b/libs/packages/sam-material-extensions/src/lib/button-group/button-group.component.ts
@@ -3,6 +3,7 @@ import {
   ContentChildren,
   EventEmitter,
   Input,
+  OnInit,
   Output,
   QueryList,
   TemplateRef,
@@ -24,15 +25,24 @@ export class SdsButtonGroupOptionComponent {
   @Input() value: any;
   @Input() checked: boolean;
   @Input('aria-label') ariaLabel: any;
+  @Input() disabled: boolean;
 }
 
 @Component({
   selector: 'sds-button-group',
   templateUrl: './button-group.component.html',
   styleUrls: ['./button-group.component.scss'],
-  host: { class: 'sds-button-group--segmented' },
+  host: {
+    class: 'sds-button-group--segmented',
+    '[class.sds-button-group--modular]': 'modularDashboard',
+  },
 })
-export class SdsButtonGroupComponent {
+export class SdsButtonGroupComponent implements OnInit {
+  ngOnInit(): void {
+    if (this.modularDashboard) {
+      this.mode = 'radio';
+    }
+  }
   @ContentChildren(SdsButtonGroupOptionComponent) buttonOptions!: QueryList<SdsButtonGroupOptionComponent>;
   classesToApply: Object = {};
 
@@ -41,6 +51,9 @@ export class SdsButtonGroupComponent {
    */
   @Input()
   mode: 'checkbox' | 'radio' = 'radio';
+
+  @Input()
+  modularDashboard: boolean = false;
 
   @Output()
   change = new EventEmitter<MatButtonToggleChange>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@gsa-sam/ngx-uswds-icons": "^17.0.0",
         "@gsa-sam/sam-formly": "^17.0.1",
         "@gsa-sam/sam-material-extensions": "^17.0.1",
-        "@gsa-sam/sam-styles": "^3.0.18",
+        "@gsa-sam/sam-styles": "^3.0.20",
         "@ngx-formly/core": "^6.2.1",
         "@ngx-formly/schematics": "^6.2.1",
         "@popperjs/core": "^2.11.8",
@@ -51,7 +51,7 @@
         "raw-loader": "^4.0.2",
         "rxjs": ">=7.5.0",
         "tslib": "^2.0.0",
-        "typescript": "^5.3.2",
+        "typescript": "<5.5.0",
         "zone.js": "^0.14.4"
       },
       "devDependencies": {
@@ -5960,9 +5960,9 @@
       }
     },
     "node_modules/@gsa-sam/sam-styles": {
-      "version": "3.0.19",
-      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.19.tgz",
-      "integrity": "sha512-XWy/jrMO9GXDjp6jMysauL6yJuB/X6/yPmbHqvV7NopEigWFBWjY6gSXKfPg+xG0MeqCDjzug10UYgBuTfuxDA==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.20.tgz",
+      "integrity": "sha512-u4tUuekrTvv6gsHYjCQaW+Gjtl6NteJOanC3gWDLs+dEGCmnm6G988ol83IJtPUeASMBSQZGEhtW17Fes3Miqw==",
       "dependencies": {
         "@uswds/uswds": "^3.3.0",
         "bootstrap-icons": "^1.10.3",
@@ -24478,7 +24478,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24494,19 +24494,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24521,7 +24521,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24539,7 +24539,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@gsa-sam/ngx-uswds-icons": "^17.0.0",
         "@gsa-sam/sam-formly": "^17.0.1",
         "@gsa-sam/sam-material-extensions": "^17.0.1",
-        "@gsa-sam/sam-styles": "^3.0.20",
+        "@gsa-sam/sam-styles": "^3.0.22",
         "@ngx-formly/core": "^6.2.1",
         "@ngx-formly/schematics": "^6.2.1",
         "@popperjs/core": "^2.11.8",
@@ -5960,9 +5960,9 @@
       }
     },
     "node_modules/@gsa-sam/sam-styles": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.20.tgz",
-      "integrity": "sha512-u4tUuekrTvv6gsHYjCQaW+Gjtl6NteJOanC3gWDLs+dEGCmnm6G988ol83IJtPUeASMBSQZGEhtW17Fes3Miqw==",
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@gsa-sam/sam-styles/-/sam-styles-3.0.22.tgz",
+      "integrity": "sha512-QbBRQP4786Y0hbyF4N/yG727imqzafNDvYLu31SUp69ox3J8Pe7M5xk2ZXWckRw+T2RftwE4hJDSF3zPPIfbhQ==",
       "dependencies": {
         "@uswds/uswds": "^3.3.0",
         "bootstrap-icons": "^1.10.3",
@@ -24478,7 +24478,6 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24494,19 +24493,16 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -24521,7 +24517,6 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -24539,7 +24534,6 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@gsa-sam/ngx-uswds-icons": "^17.0.0",
     "@gsa-sam/sam-formly": "^17.0.1",
     "@gsa-sam/sam-material-extensions": "^17.0.1",
-    "@gsa-sam/sam-styles": "^3.0.20",
+    "@gsa-sam/sam-styles": "^3.0.22",
     "@ngx-formly/core": "^6.2.1",
     "@ngx-formly/schematics": "^6.2.1",
     "@popperjs/core": "^2.11.8",


### PR DESCRIPTION
## Description
Add input modularDashboard which provides for different styling based on latest mockups.
Add demos to show new appearance.

Waiting on [sam-styles #711](https://github.com/GSA/sam-styles/pull/711)

## Motivation and Context
Resolves #1520.

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [x] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
<img width="389" alt="image" src="https://github.com/user-attachments/assets/289187f5-cba8-434d-b6e6-ab82cfc8ffde">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

