### PR TITLE
Update roles in tree-table to pass ARIA1.1 check

### DIFF
--- a/libs/packages/components/src/lib/tree-table/tree-table.component.html
+++ b/libs/packages/components/src/lib/tree-table/tree-table.component.html
@@ -1,5 +1,5 @@
 <div class="sds-tree-table--scrollable">
-  <table role="grid" class="usa-table sds-tree-table padding-x-1">
+  <table role="tree" class="usa-table sds-tree-table padding-x-1">
     <thead role="rowgroup">
       <tr role="row">
         <th>Related</th>
@@ -30,7 +30,7 @@
   let-parentRow="parentRow"
 >
   <tr
-    role="row"
+    role="treeitem"
     #tableRow
     [attr.id]="row.id"
     [attr.aria-level]="level"


### PR DESCRIPTION
## Description
Update roles in tree-table to pass ARIA 1.1 check performed by AMP. If testing standard updates to ARIA 1.2 or greater then posinset is a valid property of the row role.

## Motivation and Context
Resolves #1160 

## Type of Change (Select One and Apply Github Label)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) -> Apply bugfix label
- [ ] New feature (non-breaking change which adds functionality) -> Apply enhancement label
- [ ] Breaking change (fix or feature that would cause existing functionality to change) -> Apply breaking label

## Screenshots (if appropriate):
Passing AMP test:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/c34b0f7f-ff8a-4382-82d1-0e0286a20579">


## Which browsers have you tested?
- [ ] Internet Explorer 11
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md] document.
- [ ] My code passes the automated linter.
- [ ] This code has been reviewed by another team member and passes the reviewer checklist found in (https://github.comv/GSA/sam-ui-elements/blob/CONTRIBUTING.md)[CONTRIBUTING.md]
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code is 508 compliant as tested by AMP and JAWS
- [ ] Any dependent changes have been merged and published in downstream modules

