### PR TITLE
Document that external pull requests are not accepted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This document describes how to contribute and provide examples for new components.
 
+## Accepting Contributions
+
+This repository does not currently accept external pull requests. It is maintained by the GSA SAM design-library team as part of an internal Angular upgrade effort, and outside PRs will be closed without merging, regardless of quality.
+
+If you've found a bug or have a feature request, please [open an issue](../../issues) describing it — issues are welcome and help inform our roadmap, even though we can't accept code contributions directly at this time.
+
 - [Project Structure](#project-structure)
 - [Documentation](#documentation)
 - [Packages](#packages)


### PR DESCRIPTION
## Description

Adds an explicit "Accepting Contributions" statement to this repository's contributing guidelines, stating that external pull requests are not currently accepted.

## Motivation and Context

Confirmed with the PO in standup: this repository does not accept external contributions at this time. We currently have open PRs from outside contributors that will need to be closed as a result, so we want the policy documented up front to set expectations for anyone who finds the repo and considers opening a PR.

## Type of Change

- [x] Documentation / configuration update

## How to Test

1. Read the diff — confirm the new section reads clearly and links to the issues page as the alternative contribution path.
2. No build/lint/test impact; docs-only change.
